### PR TITLE
chore: release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The project has been broken into several pieces:
 - Grid (this repo) - the desktop app wrapper for grid-ui
 - [electron-app-manager](https://github.com/PhilippLgh/electron-app-manager) - handles app updates
 
-The MVP will be a node management tool for power users. No wallet or browser features will be included in the first release. Proposed MVP release date: first week of March 2019.
+The MVP will be a node management tool for power users. No wallet or browser features will be included in the first release.
 
 #### How can I contribute?
 

--- a/README.md
+++ b/README.md
@@ -7,27 +7,19 @@
 # Enter the Grid
 
 This is the hosting application for [Grid UI](https://github.com/ethereum/grid-ui) and can be considered a [Mist](https://github.com/ethereum/Mist) alternative in the long run.
-This project ensures that the user can update, configure and run the Grid UI web app and client binaries such as geth.
-Moreover this project can be bundled with Grid UI and create distributable installers that can be found under 'releases'.
+This project ensures that the user can update, configure and run the Grid UI web app and client binaries, such as geth.
 
 ### Quick Start
 
-First we need to install less and Grid UI:
+Install and run Grid UI:
 
 ```
-npm install -g less
 git clone https://github.com/ethereum/grid-ui.git
 cd grid-ui
-yarn && yarn run watch-css
+yarn && yarn start
 ```
 
-In another terminal, go to the grid-ui folder, type:
-
-```
-yarn run start
-```
-
-Then in a third terminal, outside the grid-ui folder and install and run grid:
+Install and run Grid:
 
 ```
 git clone https://github.com/ethereum/grid.git
@@ -51,26 +43,7 @@ In the the production mode a bundled app can be loaded from either `fs` or a rem
 
 # Release Process
 
-## Steps to release with CI
-
-- Bump version number
-- Push / merge to master
-- TODO set trigger for Electron releases (with auto-updater), grid-ui releases (without auto-updater)
-
-## Steps to test release (locally)
-
-- npm run prepare-release
-  - will download latest app release and package it with shell
-- npm run build
-- double check that release/unpacked/Grid.exe is working
-
-## Steps to release (locally)
-
-- get github access token and insert into .env as GH_TOKEN
-- TODO changelog, and release draft
-- TODO installer signing
-- npm run release -> auto publishes
-- go to github, check everything, edit description and change from draft to release
+See the developer guide [here](/RELEASE.md).
 
 # Landing page development guide
 
@@ -78,4 +51,4 @@ See instructions at [/docs](/docs/README.md).
 
 # Contributing
 
-There are many ways to get involved with this project. Get started [here](/docs/CONTRIBUTING.md).
+There are many ways to get involved with this project. Get started [here](/CONTRIBUTING.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+## Developer Guide: Releases
+
+### Background
+
+`electron-builder` is used to package up the application by CircleCI. The configuration settings can be found in `package.json`, under the `"build"` key.
+
+If you include a new top-level file to be distributed with the application, it must be added manually to the `"files"` array in the configuration settings.
+
+### Testing a release candidate locally
+
+`yarn build` will package up the app, with installers for each OS, and output them into a `release` directory.
+
+### Preparing a release (via CI)
+
+1. **Update the version number** of the release in `package.json`.
+1. **Merge the new code into `master`.** CircleCI will build the new installers (`yarn build`) and create a draft release for the new version. **Note:** if the CI builds for a version number that already exists, it will replace the assets for that version.
+1. **Write release notes.** The draft can be edited from the GitHub releases page.
+1. **Publish the release.** Before the new installers can be viewed on the website, you must manually publish the draft. Within GitHub's UI, edit the draft and select `Publish release`.
+
+### Preparing a release (manually)
+
+1. **Add the GitHub access token** to the `.env` file as `GH_TOKEN`.
+1. **Update the version number** of the release in `package.json`.
+1. **Manually initiate the release** with `yarn release`.
+1. **Write release notes.** The draft can be edited from the GitHub releases page.
+1. **Publish the release.** Before the new installers can be viewed on the website, you must manually publish the draft. Within GitHub's UI, edit the draft and select `Publish release`.
+
+### Using build channels
+
+`grid-ui` versions may be published to various build channels. Push the changes to the appropriate branch and the CI will complete the deployment. Available channels include: `dev`, `ci`, `alpha`, `beta`, `nightly`, `production`, `master`, and `release`.


### PR DESCRIPTION
#### What does it do?
First pass at documenting the build process. Closes https://github.com/ethereum/grid/issues/79.