### PR TITLE
feat: emit logs

### DIFF
--- a/WindowManager.js
+++ b/WindowManager.js
@@ -7,7 +7,7 @@ class WindowManager {
     const preloadPath = path.join(__dirname, 'preload.js')
 
     let baseOptions = {
-      width: 966,
+      width: 1059,
       height: 658,
       webPreferences: {
         preload: preloadPath,

--- a/ethereum_clients/geth.js
+++ b/ethereum_clients/geth.js
@@ -297,6 +297,7 @@ class Geth extends EventEmitter {
       const onData = data => {
         const log = data.toString()
         this.logs.push(log)
+        this.emit('log', log)
       }
 
       stderr.once('data', onStart.bind(this))


### PR DESCRIPTION
Emit on new logs.

This will remove the need to poll for new log entries in grid-ui/Terminal.jsx component, and instead can subscribe to `geth.on('log', log => { console.log('New log: ', log) })`

Also increases electron window width a little bit to make for roomier terminal.