### PR TITLE
feat: native open folder dialog

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,4 +1,6 @@
 const { ipcRenderer, remote, webFrame } = require('electron')
+const { dialog } = require('electron').remote
+
 // const rpc = require('./Rpc')
 
 // const thisWin = remote.getCurrentWindow()
@@ -41,11 +43,29 @@ window.addEventListener('message', function(event) {
 }, false);
 */
 console.log('preload loaded')
+
+const openFolderDialog = defaultPath => {
+  return new Promise((resolve, reject) => {
+    const options = {
+      defaultPath,
+      properties: ['openDirectory', 'showHiddenFiles']
+    }
+    dialog.showOpenDialog(options, filePaths => {
+      if (!filePaths || filePaths.length === 0) {
+        reject('No selection')
+        return
+      }
+      resolve(filePaths[0])
+    })
+  })
+}
+
 const Mist = {
   geth: remote.getGlobal('Geth'),
   window: {
     getArgs: () => {}
-  }
+  },
+  openFolderDialog
 }
 
 /*
@@ -67,7 +87,7 @@ const Geth = {
   },
   start: async () => {
     return rpc.send("geth.start")
-  },    
+  },
   stop: async () => {
     return rpc.send("geth.stop")
   },


### PR DESCRIPTION
#### What does it do?
Allows for `grid-ui` to open a native open folder dialog with https://github.com/ethereum/grid-ui/pull/35
<img width="395" alt="Screen Shot 2019-03-28 at 12 02 05 AM" src="https://user-images.githubusercontent.com/22116/55137303-e0c52b00-50ed-11e9-891a-7a2846a18c86.png">
