### PR TITLE
fix: ensure kill geth

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,16 +17,19 @@ const log = {
 
 const { app, dialog, Menu } = require('electron')
 
-const { AppManager, registerPackageProtocol } = require('@philipplgh/electron-app-manager')
+const {
+  AppManager,
+  registerPackageProtocol
+} = require('@philipplgh/electron-app-manager')
 registerPackageProtocol()
 
 AppManager.on('menu-available', updaterTemplate => {
   const template = getMenuTemplate()
-  
+
   // replace old updater menu with new one
   const idx = template.findIndex(mItem => mItem.label === 'Updater')
   template[idx] = updaterTemplate
-  
+
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 })
 
@@ -125,7 +128,6 @@ const startUI = async () => {
   })
 
   if (is.dev()) {
-
     // load user-provided package if possible
     if (fs.existsSync(path.join(__dirname, CONFIG_NAME))) {
       const { useDevSettings } = require(`./${CONFIG_NAME}`)
@@ -161,6 +163,10 @@ const startUI = async () => {
   */
 }
 
+app.on('quit', async () => {
+  await global.Geth.stop()
+})
+
 // ########## MAIN APP ENTRY POINT #########
 const onReady = async () => {
   // 0 prepare windows, menus etc
@@ -171,12 +177,6 @@ const onReady = async () => {
   await startUI()
 
   // 2. make geth methods available in renderer
-  // setupRpc('geth', geth)
   global.Geth = geth
-  const gethBinary = await geth.getLocalBinary()
-  if (gethBinary) {
-    //geth.start(gethBinary)
-  }
-  // else do nothing: let user decide how to setup
 }
 app.once('ready', onReady)


### PR DESCRIPTION
#### What does it do?
- Await geth stopping before quit.
- Closes https://github.com/ethereum/grid/issues/116.
#### Any helpful background information?
- Didn't see a meaningful difference between using the #quit, #will-quit, or #before-quit electron events, so just used [#quit](https://electronjs.org/docs/api/app#event-quit).
- My machine (macOS) seems to reliably kill the process before the `stop` function is able to resolve its promise, producing this error log before exiting: `Attempting to call a function in a renderer window that has been closed or released.` I think this is harmless, but still exploring more robust solutions.
