### PR TITLE
Fix: properly split logs in lines when receives a larger chunk

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -80,9 +80,12 @@ class ControlledProcess extends EventEmitter {
       }
 
       const onData = data => {
-        const log = data.toString()
-        this.logs.push(log)
-        this.emit('log', log)
+        const logLines = data
+          .toString()
+          .trim('\n')
+          .split('\n')
+        this.appendLogs(logLines)
+        this.emit('log', logLines)
       }
 
       stderr.once('data', onStart.bind(this))
@@ -113,6 +116,9 @@ class ControlledProcess extends EventEmitter {
   }
   getLogs() {
     return this.logs
+  }
+  appendLogs(lines) {
+    this.logs = this.logs.concat(lines)
   }
   async restart() {
     await this.stop()

--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -85,7 +85,7 @@ class ControlledProcess extends EventEmitter {
           .trim('\n')
           .split('\n')
         this.appendLogs(logLines)
-        this.emit('log', logLines)
+        logLines.map(l => this.emit('log', l))
       }
 
       stderr.once('data', onStart.bind(this))


### PR DESCRIPTION
Back-end fix of #157.

We can't assume all log events will come with a single line each. This fix makes sure we'll split them into lines and appends them individually to the `logs` array