### PR TITLE
fix: parity IPC path

### DIFF
--- a/ethereum_clients/client_plugins/parity.js
+++ b/ethereum_clients/client_plugins/parity.js
@@ -1,3 +1,23 @@
+function findIpcPath() {
+  let ipcPath
+
+  switch (process.platform) {
+    case 'win32': {
+      ipcPath = `${process.env.APPDATA}\\Local\\Parity\\Ethereum\\jsonrpc.ipc`
+    }
+    case 'linux': {
+      ipcPath = `~/.local/share/io.parity.ethereum/jsonrpc.ipc`
+    }
+    case 'darwin': {
+      ipcPath = `~/Library/Application\ Support/io.parity.ethereum/jsonrpc.ipc`
+    }
+    default: {
+    }
+  }
+
+  return ipcPath
+}
+
 module.exports = {
   type: 'client',
   order: 2,
@@ -6,5 +26,6 @@ module.exports = {
   // repository: 'https://github.com/paritytech/parity-ethereum'
   repository: 'https://github.com/PhilippLgh/EthCapetownWorkshop',
   prefix: `${process.platform}`, // filter github assets
-  binaryName: process.platform === 'win32' ? 'parity.exe' : 'parity'
+  binaryName: process.platform === 'win32' ? 'parity.exe' : 'parity',
+  resolveIpc: () => findIpcPath()
 }


### PR DESCRIPTION
#### What does it do?
provides jsonrpc.ipc path for parity; used to determine connection in the UI.