### PR TITLE
feat: support externally hosted plugins

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -21,6 +21,7 @@ class ControlledProcess extends EventEmitter {
     this.resolveIpc = resolveIpc
     this.debug = console.log // debug(name)
     this.ipc = undefined
+    this.stdin = undefined
     this.logs = []
     this._state = STATES.STOPPED
     this.responsePromises = []
@@ -48,7 +49,8 @@ class ControlledProcess extends EventEmitter {
 
       // Spawn process
       const proc = spawn(this.binaryPath, flags)
-      const { stdout, stderr } = proc
+      const { stdout, stderr, stdin } = proc
+      this.stdin = stdin
 
       proc.on('error', error => {
         this.state = STATES.ERROR

--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -75,7 +75,20 @@ class Plugin extends EventEmitter {
   async getLocalBinary(release) {
     const extractBinary = async (pkg, binaryName) => {
       const entries = await this.updater.getEntries(pkg)
-      const binaryEntry = entries.find(e => e.relativePath.endsWith(binaryName))
+      let binaryEntry = undefined
+      if (binaryName) {
+        binaryEntry = entries.find(e => e.relativePath.endsWith(binaryName))
+      } else {
+        // try to detect binary
+        // const isExecutable = mode => Boolean((mode & 0o0001) || (mode & 0o0010) || (mode & 0o0100))
+        if (process.platform === 'win32') {
+          binaryEntry = entries.find(e => e.relativePath.endsWith('.exe'))
+        } else {
+          // no heuristic available: pick first
+          binaryEntry = entries[0]
+        }
+      }
+
       const destAbs = path.join(this.cacheDir, binaryName)
       // The unlinking might fail if the binary is e.g. being used by another instance
       if (fs.existsSync(destAbs)) {

--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -10,9 +10,28 @@ class Plugin extends EventEmitter {
   constructor(config) {
     super()
     const { name, repository, filter, prefix } = config
+    if (!name || !repository) {
+      throw new Error(
+        'plugin is missing required fields "name" or "repository"'
+      )
+    }
     this.updater = getBinaryUpdater(repository, name, filter, prefix)
     this.config = config
     this.process = undefined
+    if (config.onInputRequested) {
+      this.on('log', log => {
+        try {
+          config.onInputRequested(log, input => {
+            this.process.stdin.write(`${input}\n`)
+          })
+        } catch (error) {
+          console.log(
+            `error: plugin ${this.name} could not provide input`,
+            error
+          )
+        }
+      })
+    }
   }
   get cacheDir() {
     return this.updater.cacheDir
@@ -80,6 +99,9 @@ class Plugin extends EventEmitter {
         binaryEntry = entries.find(e => e.relativePath.endsWith(binaryName))
       } else {
         // try to detect binary
+        console.log(
+          'no "binaryName" specified - trying to auto-detect executable within package:'
+        )
         // const isExecutable = mode => Boolean((mode & 0o0001) || (mode & 0o0010) || (mode & 0o0100))
         if (process.platform === 'win32') {
           binaryEntry = entries.find(e => e.relativePath.endsWith('.exe'))
@@ -87,6 +109,15 @@ class Plugin extends EventEmitter {
           // no heuristic available: pick first
           binaryEntry = entries[0]
         }
+      }
+
+      if (!binaryEntry) {
+        throw new Error(
+          'binary not found in package: try to specify binaryName'
+        )
+      } else {
+        binaryName = binaryEntry.file.name
+        console.log('auto-detected binary:', binaryName)
       }
 
       const destAbs = path.join(this.cacheDir, binaryName)

--- a/ethereum_clients/PluginHost.js
+++ b/ethereum_clients/PluginHost.js
@@ -97,9 +97,21 @@ class PluginHost extends EventEmitter {
           if (latest.remote) {
             latest = await pluginManager.download(latest)
             if (!latest) {
-              console.log('error: plugin could not be fetched')
-              return undefined
+              throw new Error('error: plugin could not be fetched')
             }
+          }
+          // plugin verification necessary for remote plugins:
+          if (!latest.verificationResult) {
+            throw new Error('external plugin has no verification info')
+          }
+          const { isValid, isTrusted } = latest.verificationResult
+          if (!isValid) {
+            throw new Error('invalid plugin signature: unsigned or corrupt?')
+          }
+          if (!isTrusted) {
+            console.log(
+              "WARNING: the plugin is signed but the author's key is unknown"
+            )
           }
           const plugin = await this.loadPluginFromPackage(pluginManager, latest)
           return plugin

--- a/ethereum_clients/PluginHost.js
+++ b/ethereum_clients/PluginHost.js
@@ -1,34 +1,132 @@
 const fs = require('fs')
 const path = require('path')
+const { EventEmitter } = require('events')
 const { Plugin, PluginProxy } = require('./Plugin')
+const { getPluginCachePath } = require('./util')
+const { AppManager } = require('@philipplgh/electron-app-manager')
+
+function requireFromString(src, filename) {
+  var Module = module.constructor
+  var m = new Module()
+  m._compile(src, filename)
+  return m.exports
+}
 
 // TODO add file to electron packaged files
-class PluginHost {
+class PluginHost extends EventEmitter {
   constructor() {
+    super()
     this.plugins = []
     this.discover()
+      .then(plugins => {
+        this.plugins = this.plugins.concat(plugins)
+        // TODO emit plugins discovered
+      })
+      .catch(err => console.log('plugins could not be loaded', err))
+
+    this.discoverRemote()
+      .then(plugins => {
+        this.plugins = this.plugins.concat(plugins)
+        console.log(`${plugins.length} remote plugins found`)
+      })
+      .catch(err => {
+        console.log('remote plugins could not be loaded', err)
+      })
+      .finally(() => {
+        this.emit('plugins-loaded')
+      })
   }
-  // TODO should be async and not block UI init
-  discover() {
+  loadPluginFromFile(fullPath) {
+    const pluginConfig = require(fullPath)
+    // 2. TODO validate / verify
+    const plugin = new Plugin(pluginConfig)
+    return plugin
+  }
+  async loadPluginFromPackage(pkg) {
+    const index = await pluginManager.getEntry(pkg, 'package/index.js')
+    const indexContent = await index.file.readContent()
+    const pluginConfig = requireFromString(
+      indexContent.toString(),
+      `${pkg.location}/package/index.js`
+    )
+    const plugin = new Plugin(pluginConfig)
+    return plugin
+  }
+  async discoverRemote() {
+    const PLUGIN_DIR = path.join(__dirname, 'client_plugins')
+    let remotePluginList = []
+    try {
+      remotePluginList = JSON.parse(
+        fs.readFileSync(path.join(PLUGIN_DIR, 'plugins.json'))
+      )
+    } catch (error) {
+      console.log('Error: could not parse plugin list', error)
+    }
+    let releases = remotePluginList.map(async pluginShortInfo => {
+      try {
+        const { location } = pluginShortInfo
+        if (fs.existsSync(location)) {
+          // load package from provided path
+          // FIXME allow this only in dev mode
+          if (fs.statSync(location).isDirectory()) {
+            // TODO plugin can be named differently and specified in package.json
+            const plugin = this.loadPluginFromFile(
+              path.join(location, 'index.js')
+            )
+            return plugin
+          } else {
+            const plugin = this.loadPluginFromFile(location)
+            return plugin
+          }
+        } else {
+          const pluginManager = new AppManager({
+            repository: pluginShortInfo.repository,
+            auto: false,
+            paths: [],
+            cacheDir: getPluginCachePath(pluginShortInfo.name)
+          })
+          // load package from cache or server:
+          let latest = await pluginManager.getLatest()
+          if (!latest) {
+            return undefined
+          }
+          // download if necessary -> no cached found
+          if (latest.remote) {
+            latest = await pluginManager.download(latest)
+            if (!latest) {
+              console.log('error: plugin could not be fetched')
+              return undefined
+            }
+          }
+        }
+        const plugin = await this.loadPluginFromPackage(latest)
+        return plugin
+      } catch (error) {
+        const { name } = pluginShortInfo
+        console.log(`remote plugin ${name} could not be loaded`, error)
+        return undefined
+      }
+    })
+    const plugins = await Promise.all(releases)
+    return plugins.filter(p => p !== undefined)
+  }
+  async discover() {
     const PLUGIN_DIR = path.join(__dirname, 'client_plugins')
     const pluginFiles = fs.readdirSync(PLUGIN_DIR)
-
     console.time('plugin init')
     const plugins = []
     pluginFiles.forEach(f => {
+      if (!f.endsWith('.js')) return
       try {
         const fullPath = path.join(PLUGIN_DIR, f)
-        const pluginConfig = require(fullPath)
-        // 2. TODO validate / verify
-        const plugin = new Plugin(pluginConfig)
+        const plugin = this.loadPluginFromFile(fullPath)
         plugins.push(plugin)
       } catch (error) {
         console.log(`plugin ${f} could not be loaded`, error)
       }
     })
     console.timeEnd('plugin init')
-
-    this.plugins = [...plugins]
+    return plugins
   }
   getAllMetadata() {
     return this.plugins.map(p => p.config)
@@ -50,6 +148,7 @@ class PluginHost {
 
 const registerGlobalPluginHost = () => {
   global.PluginHost = new PluginHost()
+  return global.PluginHost
 }
 
 module.exports.registerGlobalPluginHost = registerGlobalPluginHost

--- a/ethereum_clients/PluginHost.js
+++ b/ethereum_clients/PluginHost.js
@@ -126,6 +126,7 @@ class PluginHost extends EventEmitter {
         }
         return undefined
       } catch (error) {
+        const { name: pluginName } = pluginShortInfo
         console.log(
           `error: remote plugin ${pluginName} could not be loaded`,
           error

--- a/ethereum_clients/client_plugins/plugins.json
+++ b/ethereum_clients/client_plugins/plugins.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "raiden",
+    "displayName": "Raiden Network",
+    "type": "tools",
+    "author": {
+      "name": "Philipp Langhans",
+      "email": "philipp@ethereum.org",
+      "address": "0x00000000000000000000"
+    },
+    "location": "D:/Projects/grid-raiden-plugin",
+    "order": 6
+  },
+  {
+    "name": "bla",
+    "displayName": "Raiden Network",
+    "type": "tools",
+    "author": {
+      "name": "Philipp Langhans",
+      "email": "philipp@ethereum.org",
+      "address": "0x00000000000000000000"
+    },
+    "repository": "https://github.com/PhilippLgh/grid-raiden-extensions",
+    "order": 6
+  }
+]

--- a/ethereum_clients/client_plugins/plugins.json
+++ b/ethereum_clients/client_plugins/plugins.json
@@ -6,21 +6,8 @@
     "author": {
       "name": "Philipp Langhans",
       "email": "philipp@ethereum.org",
-      "address": "0x00000000000000000000"
+      "address": "02cd3ee7afec844b8f0d0065ba4ae86c2035dd3a"
     },
-    "location": "D:/Projects/grid-raiden-plugin",
-    "order": 6
-  },
-  {
-    "name": "bla",
-    "displayName": "Raiden Network",
-    "type": "tools",
-    "author": {
-      "name": "Philipp Langhans",
-      "email": "philipp@ethereum.org",
-      "address": "0x00000000000000000000"
-    },
-    "repository": "https://github.com/PhilippLgh/grid-raiden-extensions",
-    "order": 6
+    "location": "https://github.com/PhilippLgh/grid-raiden-extension"
   }
 ]

--- a/ethereum_clients/util.js
+++ b/ethereum_clients/util.js
@@ -3,16 +3,35 @@ const path = require('path')
 const { AppManager } = require('@philipplgh/electron-app-manager')
 
 const getUserDataPath = () => {
-  const USER_DATA_PATH = 'electron' in process.versions
-    ? require('electron').app.getPath('userData')
-    : path.join(process.env.APPDATA, 'grid')
+  const USER_DATA_PATH =
+    'electron' in process.versions
+      ? require('electron').app.getPath('userData')
+      : path.join(process.env.APPDATA, 'grid')
   if (!fs.existsSync(USER_DATA_PATH)) {
     fs.mkdirSync(USER_DATA_PATH)
   }
   return USER_DATA_PATH
 }
 
-const getCachePath = (name) => {
+const getPluginCachePath = name => {
+  let cachePath
+  if (process.env.NODE_ENV === 'test') {
+    cachePath = path.join(__dirname, `client_plugins`, `${name}`)
+  } else if (process.env.NODE_ENV === 'development') {
+    cachePath = path.join(__dirname, `client_plugins`, `${name}`)
+  } else {
+    const USER_DATA_PATH = getUserDataPath()
+    cachePath = path.join(USER_DATA_PATH, `client_plugins`, `${name}`)
+  }
+
+  if (!fs.existsSync(cachePath)) {
+    fs.mkdirSync(cachePath)
+  }
+
+  return cachePath
+}
+
+const getCachePath = name => {
   let cachePath
   if (process.env.NODE_ENV === 'test') {
     cachePath = path.join(__dirname, '/../test', 'fixtures', `bin_${name}`)
@@ -28,14 +47,12 @@ const getCachePath = (name) => {
   }
 
   return cachePath
-
 }
 
 const getBinaryUpdater = (repo, name, filter, prefix, cachePath) => {
-
   let includes = []
   let excludes = []
-  
+
   if (filter && filter.name) {
     const { name } = filter
     excludes = name.excludes
@@ -53,7 +70,10 @@ const getBinaryUpdater = (repo, name, filter, prefix, cachePath) => {
     cacheDir: cachePath,
     filter: ({ fileName }) => {
       fileName = fileName.toLowerCase()
-      return (!includes || includes.every(val => fileName.indexOf(val) >= 0)) && (!excludes || excludes.every(val => fileName.indexOf(val) === -1))
+      return (
+        (!includes || includes.every(val => fileName.indexOf(val) >= 0)) &&
+        (!excludes || excludes.every(val => fileName.indexOf(val) === -1))
+      )
     },
     prefix
   })
@@ -61,5 +81,6 @@ const getBinaryUpdater = (repo, name, filter, prefix, cachePath) => {
 
 module.exports = {
   getCachePath,
+  getPluginCachePath,
   getBinaryUpdater
 }

--- a/ethereum_clients/util.js
+++ b/ethereum_clients/util.js
@@ -14,16 +14,22 @@ const getUserDataPath = () => {
 }
 
 const getPluginCachePath = name => {
-  let cachePath
+  let CLIENT_PLUGINS
+
   if (process.env.NODE_ENV === 'test') {
-    cachePath = path.join(__dirname, `client_plugins`, `${name}`)
+    CLIENT_PLUGINS = path.join(__dirname, `client_plugins`)
   } else if (process.env.NODE_ENV === 'development') {
-    cachePath = path.join(__dirname, `client_plugins`, `${name}`)
+    CLIENT_PLUGINS = path.join(__dirname, `client_plugins`)
   } else {
     const USER_DATA_PATH = getUserDataPath()
-    cachePath = path.join(USER_DATA_PATH, `client_plugins`, `${name}`)
+    CLIENT_PLUGINS = path.join(USER_DATA_PATH, `client_plugins`)
   }
 
+  if (!fs.existsSync(CLIENT_PLUGINS)) {
+    fs.mkdirSync(CLIENT_PLUGINS)
+  }
+
+  const cachePath = path.join(CLIENT_PLUGINS, name)
   if (!fs.existsSync(cachePath)) {
     fs.mkdirSync(cachePath)
   }

--- a/index.js
+++ b/index.js
@@ -184,9 +184,12 @@ const startUI = async () => {
 
 // ########## MAIN APP ENTRY POINT #########
 const onReady = async () => {
-  registerGlobalPluginHost()
+  const pluginHost = registerGlobalPluginHost()
 
-  // 1. start UI for quick user-feedback without long init procedures
-  await startUI()
+  pluginHost.on('plugins-loaded', async () => {
+    // FIXME don't defer start
+    // 1. start UI for quick user-feedback without long init procedures
+    await startUI()
+  })
 }
 app.once('ready', onReady)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "env-cmd .env build"
   },
   "dependencies": {
-    "@philipplgh/electron-app-manager": "^0.28.0",
+    "@philipplgh/electron-app-manager": "^0.31.0",
     "debug": "^4.1.1"
   },
   "peerDependencies": {},

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "env-cmd .env build"
   },
   "dependencies": {
-    "@philipplgh/electron-app-manager": "^0.31.0",
+    "@philipplgh/electron-app-manager": "^0.32.0",
     "debug": "^4.1.1"
   },
   "peerDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,37 +48,18 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@philipplgh/electron-app-manager@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@philipplgh/electron-app-manager/-/electron-app-manager-0.28.0.tgz#760444e4d57ee7bca89f41e2a6d082a7353c2718"
-  integrity sha512-B/ThvofEqNDyc/Y31GLHhvX+yDoZ47ksfQxLLv8gKbU9GoHNSrzMx4L2IiBiJnBsAEmN+K95vKYetrbAqxwdQg==
+"@philipplgh/electron-app-manager@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@philipplgh/electron-app-manager/-/electron-app-manager-0.31.0.tgz#893d50d3ab0d1dfec1a076772b183b821a0fdea7"
+  integrity sha512-B76Jx/Y/H9cD7uXFHkOmdagxDD4E0zTehvtHRCpr6m6W7s/IaDivTcrKrOqlm6BividvseP5cFwHr2SEd779TA==
   dependencies:
     "@octokit/rest" "^15.13.1"
-    "@philipplgh/ethpkg" "^0.2.2"
     electron-updater "4.0.6"
+    ethpkg "^0.3.0"
     openpgp "^4.4.5"
     semver "^5.6.0"
     tar-stream "^1.6.2"
     xml2js "^0.4.19"
-
-"@philipplgh/ethpkg@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@philipplgh/ethpkg/-/ethpkg-0.2.2.tgz#5a274735665f1ef9715968ad38e48d14212de35f"
-  integrity sha512-8NB8Puq3Ft/Zm34le5OkhTFPtmG9+fHUBA5HPhY8Zk1CiZ/QQ1hCf5W5Si0rkVlBwzDgWr2MsVZbkrhwhAXRdg==
-  dependencies:
-    asn1.js "^5.0.1"
-    base64url "^3.0.1"
-    chalk "^2.4.2"
-    clime "^0.5.10"
-    enquirer "^2.3.0"
-    ethereumjs-util "6.0.0"
-    file-type "^10.9.0"
-    jsonwebtoken "^8.4.0"
-    jszip "^3.1.5"
-    keythereum "^1.0.4"
-    ora "^3.1.0"
-    secp256k1 "^3.6.2"
-    tar-stream "^2.0.1"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -129,9 +110,9 @@ ansi-align@^2.0.0:
     string-width "^2.0.0"
 
 ansi-colors@^3.2.1:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
-  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^3.0.0:
   version "3.2.0"
@@ -148,10 +129,10 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -368,14 +349,14 @@ before-after-hook@^1.1.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.3.2.tgz#7bfbf844ad670aa7a96b5a4e4e15bd74b08ed66b"
   integrity sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==
 
-bindings@^1.2.1:
+bindings@^1.2.1, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip66@^1.1.3:
+bip66@^1.1.3, bip66@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
   integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
@@ -768,10 +749,10 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
-  integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
+cli-spinners@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.1.0.tgz#22c34b4d51f573240885b201efda4e4ec9fff3c7"
+  integrity sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==
 
 cli-truncate@^0.2.1:
   version "0.2.1"
@@ -935,7 +916,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.2:
+create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
@@ -1303,7 +1284,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0, elliptic@^6.2.3:
+elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
@@ -1408,6 +1389,25 @@ ethjs-util@^0.1.6:
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
+
+ethpkg@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ethpkg/-/ethpkg-0.3.0.tgz#b2f0feaae8cf23420099e99598b9d87c9b8f9db5"
+  integrity sha512-nyKi7Al7yPk5DGJA/WGQLU1gEmJ8gFLPaqW9gm9yWFWcJl87hsY/IllpqUNOKk/7AUvZ0mNGyb0efB9bqPui9g==
+  dependencies:
+    asn1.js "^5.0.1"
+    base64url "^3.0.1"
+    chalk "^2.4.2"
+    clime "^0.5.10"
+    enquirer "^2.3.0"
+    ethereumjs-util "6.0.0"
+    file-type "^10.9.0"
+    jsonwebtoken "^8.4.0"
+    jszip "^3.1.5"
+    keythereum "^1.0.4"
+    ora "^3.1.0"
+    secp256k1 "^3.6.2"
+    tar-stream "^2.0.1"
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -1561,9 +1561,9 @@ figures@^2.0.0:
     escape-string-regexp "^1.0.5"
 
 file-type@^10.9.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.9.0.tgz#f6c12c7cb9e6b8aeefd6917555fd4f9eadf31891"
-  integrity sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w==
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.11.0.tgz#2961d09e4675b9fb9a3ee6b69e9cd23f43fd1890"
+  integrity sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -2314,11 +2314,11 @@ jsonfile@^4.0.0:
     graceful-fs "^4.1.6"
 
 jsonwebtoken@^8.4.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#ebd0ca2a69797816e1c5af65b6c759787252947e"
-  integrity sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
   dependencies:
-    jws "^3.2.1"
+    jws "^3.2.2"
     lodash.includes "^4.3.0"
     lodash.isboolean "^3.0.3"
     lodash.isinteger "^4.0.4"
@@ -2340,30 +2340,30 @@ jsprim@^1.2.2:
     verror "1.10.0"
 
 jszip@^3.1.5:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.2.0.tgz#1c179e8692777490ca4e9b8f3ced08f9b820da2c"
-  integrity sha512-4WjbsaEtBK/DHeDZOPiPw5nzSGLDEDDreFRDEgnoMwmknPjTqa+23XuYFk6NiGbeiAeZCctiQ/X/z0lQBmDVOQ==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.2.1.tgz#c5d32df7274042282b157efb16e522b43435e01a"
+  integrity sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-jwa@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.3.0.tgz#061a7c3bb8ab2b3434bb2f432005a8bb7fca0efa"
-  integrity sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
   dependencies:
     buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.1.tgz#d79d4216a62c9afa0a3d5e8b5356d75abdeb2be5"
-  integrity sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
   dependencies:
-    jwa "^1.2.0"
+    jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
 keccak@1.4.0, keccak@^1.0.2:
@@ -2821,10 +2821,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-nan@^2.0.8, nan@^2.2.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+nan@^2.0.8, nan@^2.13.2, nan@^2.2.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -2983,15 +2983,15 @@ openpgp@^4.4.5:
     web-stream-tools "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
 
 ora@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-3.1.0.tgz#dbedd8c03b5d017fb67083e87ee52f5ec89823ed"
-  integrity sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
   dependencies:
     chalk "^2.4.2"
     cli-cursor "^2.1.0"
-    cli-spinners "^1.3.1"
+    cli-spinners "^2.0.0"
     log-symbols "^2.2.0"
-    strip-ansi "^5.0.0"
+    strip-ansi "^5.2.0"
     wcwidth "^1.0.1"
 
 os-locale@^3.0.0:
@@ -3065,12 +3065,12 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@^1.0.6, pako@~1.0.2:
+pako@^1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
   integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
-pako@^1.0.7:
+pako@^1.0.7, pako@~1.0.2:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
@@ -3397,9 +3397,9 @@ readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable
     util-deprecate "~1.0.1"
 
 readable-stream@^3.0.1, readable-stream@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
-  integrity sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -3555,9 +3555,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     inherits "^2.0.1"
 
 rlp@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.2.tgz#e6677b83cca9105371d930e01d8ffc1263139d05"
-  integrity sha512-Ng2kJEN731Sfv4ZAY2i0ytPMc0BbJKBsVNl0QZY8LxOWSwd+1xpg+fpSRfaMn0heHU447s6Kgy8qfHZR0XTyVw==
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.3.tgz#7f94aef86cec412df87d5ea1d8cb116a47d45f0e"
+  integrity sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==
   dependencies:
     bn.js "^4.11.1"
     safe-buffer "^5.1.1"
@@ -3625,18 +3625,18 @@ secp256k1@3.5.0:
     safe-buffer "^5.1.0"
 
 secp256k1@^3.0.1, secp256k1@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.6.2.tgz#da835061c833c74a12f75c73d2ec2e980f00dc1f"
-  integrity sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.7.0.tgz#e85972f847b586cc4b2acd69497d3f80afaa7505"
+  integrity sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==
   dependencies:
-    bindings "^1.2.1"
-    bip66 "^1.1.3"
-    bn.js "^4.11.3"
-    create-hash "^1.1.2"
+    bindings "^1.5.0"
+    bip66 "^1.1.5"
+    bn.js "^4.11.8"
+    create-hash "^1.2.0"
     drbg.js "^1.0.1"
-    elliptic "^6.2.3"
-    nan "^2.2.1"
-    safe-buffer "^5.1.0"
+    elliptic "^6.4.1"
+    nan "^2.13.2"
+    safe-buffer "^5.1.2"
 
 "seek-bzip@github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209":
   version "1.0.5-git"
@@ -3954,12 +3954,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
-  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
-    ansi-regex "^4.0.0"
+    ansi-regex "^4.1.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@philipplgh/electron-app-manager@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@philipplgh/electron-app-manager/-/electron-app-manager-0.31.0.tgz#893d50d3ab0d1dfec1a076772b183b821a0fdea7"
-  integrity sha512-B76Jx/Y/H9cD7uXFHkOmdagxDD4E0zTehvtHRCpr6m6W7s/IaDivTcrKrOqlm6BividvseP5cFwHr2SEd779TA==
+"@philipplgh/electron-app-manager@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@philipplgh/electron-app-manager/-/electron-app-manager-0.32.0.tgz#145f1959d1310245601de30ecb7597ce98931ab5"
+  integrity sha512-Wz+k+uHJGShdZWszUZj6HG/XL0ObDKceHt3YDHX71FyepMPmcNwBakHXWZRzZ50rA29EyxQEmkULCT90XSSTgw==
   dependencies:
     "@octokit/rest" "^15.13.1"
     electron-updater "4.0.6"


### PR DESCRIPTION
#### What does it do?

It extends the PluginHost with functionality to process a list `plugins.json` of externally hosted plugins and allows to download & cache them, verify their signatures and eventually load them in the main process during runtime. These plugins are stored in a path outside of the main app so that changes to them don't require elevated user permissions or re-installation.

#### Any helpful background information?

The purpose of this PR is to give external projects more control and autonomy over their integrations and the release lifecycle. Moreover, changes to external plugins won't affect Grid's release cycle since such plugins can be updated, removed and reloaded during runtime.

*Problem*: the renderer start is deferred until *all* plugins (local & remote) are processed. This is mostly done because otherwise it would require changes in the state handling in grid-ui. An event hook `plugins-loaded` was added to allow the UI to listen for state changes.

#### New dependencies? What are they used for?

It will require a newer version of electron-app-manager that includes the verification info in the plugin's release metadata.

#### Relevant screenshots?
