### PR TITLE
feat: add start cmd to logs

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -47,6 +47,10 @@ class ControlledProcess extends EventEmitter {
 
       flags = flags || []
 
+      // Add start cmd to logs
+      const cmd = `${this.binaryPath} ${flags.join(' ')}`
+      this.logs.push(cmd)
+
       // Spawn process
       const proc = spawn(this.binaryPath, flags)
       const { stdout, stderr, stdin } = proc


### PR DESCRIPTION
#### What does it do?
Adds start cmd to first line of logs

<img width="939" alt="Screen Shot 2019-05-21 at 8 46 57 AM" src="https://user-images.githubusercontent.com/22116/58111017-79839e80-7ba5-11e9-90b9-beae75df3553.png">

Closes https://github.com/ethereum/grid/issues/213