### PR TITLE
fix: remove stale parity config

### DIFF
--- a/ethereum_clients/client_plugins/parity.js
+++ b/ethereum_clients/client_plugins/parity.js
@@ -29,12 +29,6 @@ module.exports = {
   repository: 'https://github.com/PhilippLgh/EthCapetownWorkshop',
   prefix: `${process.platform}`, // filter github assets
   binaryName: process.platform === 'win32' ? 'parity.exe' : 'parity',
-  config: {
-    default: {
-      network: 'mainnet',
-      syncMode: 'warp'
-    }
-  },
   settings: [
     {
       id: 'network',


### PR DESCRIPTION
#### What does it do?
`config` removed in favor of defaults within `settings`