### PR TITLE
fix: geth flag pattern

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -67,7 +67,7 @@ module.exports = {
       id: 'dataDir',
       default: dataDir,
       label: 'Data Directory',
-      flag: '--datadir %s',
+      flag: '--datadir="%s"',
       type: 'path'
     },
     {
@@ -94,7 +94,7 @@ module.exports = {
       default: 'light',
       label: 'Sync Mode',
       options: ['fast', 'full', 'light'],
-      flag: '--syncmode %s'
+      flag: '--syncmode=%s'
     },
     {
       id: 'cache',

--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -100,7 +100,7 @@ module.exports = {
       id: 'cache',
       default: '2048',
       label: 'Cache',
-      flag: '--cache %s'
+      flag: '--cache=%s'
     }
   ]
 }


### PR DESCRIPTION
#### What does it do?
This pr encloses datadir in quotes, so if the field is left blank, it does not take the following flag as a parameter.

Fixes use case described below:

> Within geth config, empty `dataDir` field and try to start it.

Please try it in current grid then on this PR.

Closes https://github.com/ethereum/grid/issues/237