### PR TITLE
chore: fetching parity binaries from another repo

### DIFF
--- a/ethereum_clients/client_plugins/parity.js
+++ b/ethereum_clients/client_plugins/parity.js
@@ -26,7 +26,7 @@ module.exports = {
   displayName: 'Parity',
   name: 'parity',
   // repository: 'https://github.com/paritytech/parity-ethereum'
-  repository: 'https://github.com/PhilippLgh/EthCapetownWorkshop',
+  repository: 'https://github.com/evertonfraga/releases-parity',
   prefix: `${process.platform}`, // filter github assets
   binaryName: process.platform === 'win32' ? 'parity.exe' : 'parity',
   settings: [


### PR DESCRIPTION
#### What does it do?

Grabs Parity releases from a mirror repository, as app manager does not support unpackaged binaries. this new mirror is maintained by myself for now.

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?
