### PR TITLE
ci: publishing assets only from `master`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ aliases:
 
   - &run_script
     run: | 
-      if [[ $CIRCLE_BRANCH == 'master' ]]; then
+      if [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
         yarn release --$GRID_ENV;
       else
         yarn build --$GRID_ENV;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,11 @@ aliases:
     run: 
       name: "Building app (deploy if on master)"
       command: | 
-      if [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
-        yarn release --$GRID_ENV;
-      else
-        yarn build --$GRID_ENV;
-      fi;
+        if [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
+          yarn release --$GRID_ENV;
+        else
+          yarn build --$GRID_ENV;
+        fi;
 
 
   - &run_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,9 @@ aliases:
     run: yarn test:e2e -s
 
   - &run_script
-    run: | 
+    run: 
+      name: "Building app (deploy if on master)"
+      command: | 
       if [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
         yarn release --$GRID_ENV;
       else


### PR DESCRIPTION
Here we want to compare the two outcomes of builds made against master and other branches: 
```
 - &run_script
    run: | 
      if [[ $CIRCLE_BRANCH == 'master' ]]; then
        yarn release --$GRID_ENV;
      else
        yarn build --$GRID_ENV;
      fi;
```
https://github.com/ethereum/grid/blob/master/.circleci/config.yml#L58-L63

Closes #229