### PR TITLE
Fix aleth filter

### DIFF
--- a/ethereum_clients/client_plugins/aleth.js
+++ b/ethereum_clients/client_plugins/aleth.js
@@ -1,20 +1,3 @@
-let platform
-
-switch (process.platform) {
-  case 'win32': {
-    platform = 'Windows'
-    break
-  }
-  case 'linux': {
-    platform = 'Linux'
-    break
-  }
-  case 'darwin': {
-    platform = 'Darwin'
-    break
-  }
-}
-
 module.exports = {
   type: 'client',
   order: 3,
@@ -22,9 +5,5 @@ module.exports = {
   name: 'aleth',
   repository: 'https://github.com/ethereum/aleth',
   binaryName: 'aleth',
-  filter: {
-    name: {
-      includes: [platform]
-    }
-  }
+  prefix: process.platform
 }

--- a/ethereum_clients/client_plugins/aleth.js
+++ b/ethereum_clients/client_plugins/aleth.js
@@ -1,8 +1,30 @@
+let platform
+
+switch (process.platform) {
+  case 'win32': {
+    platform = 'Windows'
+    break
+  }
+  case 'linux': {
+    platform = 'Linux'
+    break
+  }
+  case 'darwin': {
+    platform = 'Darwin'
+    break
+  }
+}
+
 module.exports = {
   type: 'client',
   order: 3,
   displayName: 'Aleth',
   name: 'aleth',
   repository: 'https://github.com/ethereum/aleth',
-  binaryName: 'aleth'
+  binaryName: 'aleth',
+  filter: {
+    name: {
+      includes: [platform]
+    }
+  }
 }


### PR DESCRIPTION
#### What does it do?

Uses `prefix` to filter Aleth releases for mac / linux.

Fixes #240.

### To test
Open Aleth plugin and check if all releases are for the current platform. Keep in mind they do not have windows binaries for all releases