### PR TITLE
feat: RPC Tester App

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -41,6 +41,7 @@ class ControlledProcess extends EventEmitter {
     return new Promise((resolve, reject) => {
       this.state = STATES.STARTING
       this.emit('starting')
+      this.emit('newState', 'starting')
       this.debug('Emit: starting')
       this.debug('Start: ', this.binaryPath)
       this.debug('Flags: ', flags)
@@ -67,6 +68,7 @@ class ControlledProcess extends EventEmitter {
         if (code === 0) {
           this.state = STATES.STOPPED
           this.emit('stopped')
+          this.emit('newState', 'stopped')
           this.debug('Emit: stopped')
           return
         }
@@ -83,6 +85,7 @@ class ControlledProcess extends EventEmitter {
       const onStart = () => {
         this.state = STATES.STARTED
         this.emit('started')
+        this.emit('newState', 'started')
         this.debug('Emit: started')
         // Check for and connect IPC in 1s
         setTimeout(async () => {
@@ -165,13 +168,16 @@ class ControlledProcess extends EventEmitter {
       const onIpcConnect = () => {
         this.state = STATES.CONNECTED
         this.emit('connected')
+        this.emit('newState', 'connected')
         this.debug('Emit: connected')
         resolve(this.state)
         this.debug('IPC Connected')
       }
 
       const onIpcEnd = () => {
-        this.state = STATES.STOPPED
+        this.state = STATES.DISCONNECTED
+        this.emit('disconnected')
+        this.emit('newState', 'disconnected')
         this.ipc = null
         this.debug('IPC Connection Ended')
       }

--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -68,9 +68,11 @@ class Plugin extends EventEmitter {
     // FIXME memory leaks start here:
     // forward all events from the spawned process
     let eventTypes = [
+      'newState',
       'starting',
       'started',
       'connected',
+      'disconnected',
       'error',
       'stopped',
       'log',

--- a/grid_apps/apps.json
+++ b/grid_apps/apps.json
@@ -24,5 +24,11 @@
     "description": "Example how to build a wallet with Grid",
     "screenshot": "https://github.com/PhilippLgh/ethereum-grid-tutorials/raw/master/assets/Wallet-Starter.png",
     "url": "package://github.com/PhilippLgh/grid-wallet"
+  },
+  {
+    "name": "Grid RPC Tester",
+    "description": "Grid app to test RPC endpoints",
+    "screenshot": "https://i.imgur.com/zI5QLEv.png",
+    "url": "package://github.com/ryanio/grid-rpc-app"
   }
 ]

--- a/preload-webview.js
+++ b/preload-webview.js
@@ -1,26 +1,35 @@
 const { ipcRenderer, remote, webFrame } = require('electron')
 const PluginHost = remote.getGlobal('PluginHost')
 
+const clientInterface = client => {
+  return {
+    name: client.name,
+    displayName: client.displayName,
+    sendRpc: async (method, params) => {
+      return client.rpc(method, params)
+    },
+    getState: () => {
+      return client.state
+    },
+    execute: command => {
+      client.execute(command)
+    },
+    on: (eventName, handler) => {
+      return client.on(eventName, handler)
+    },
+    off: (eventName, handler) => {
+      return client.removeListener(eventName, handler)
+    }
+  }
+}
+
 window.grid = {
   version: '0.1.0',
+  getAllPlugins: () => {
+    return PluginHost.getAllPlugins().map(client => clientInterface(client))
+  },
   getClient: name => {
-    let client = PluginHost.getAllPlugins().find(p => p.name === name)
-    return {
-      sendRpc: async (method, params) => {
-        return client.rpc(method, params)
-      },
-      getState: () => {
-        return client.state
-      },
-      execute: command => {
-        client.execute(command)
-      },
-      on: (eventName, handler) => {
-        return client.on(eventName, handler)
-      },
-      off: (eventName, handler) => {
-        return client.removeListener(eventName, handler)
-      }
-    }
+    const client = PluginHost.getAllPlugins().find(p => p.name === name)
+    return clientInterface(client)
   }
 }


### PR DESCRIPTION
#### What does it do?
Adds a [Grid RPC Tester app](https://github.com/ryanio/grid-rpc-app) that detects plugins and sends RPC commands to them, or can set to a custom endpoint.

#### New grid features
1. Adds `grid.getAllPlugins()` to populate plugin dropdown list
2. Emits a new event `newState` for any new state updates. I developed this pattern for my clef app, which makes it useful to listen to one event for new plugin status updates, rather than creating a new listener for every 'starting'|'started'|'connected'|'stopped' etc.
   1. Also adds a new state `disconnected` for a plugin that's still running but whose rpc/ipc got disconnected

#### Relevant screenshots?
<img width="1022" alt="Screen Shot 2019-06-15 at 8 19 55 PM" src="https://user-images.githubusercontent.com/22116/59558648-af9d1e00-8fab-11e9-9e82-6a65cc8f19cc.png">

---

Closes https://github.com/ethereum/grid/issues/263
Closes https://github.com/ethereum/grid/issues/256