### PR TITLE
feat: expands showOpenDialog to accept `file` or `directory`

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -68,7 +68,7 @@ module.exports = {
       default: dataDir,
       label: 'Data Directory',
       flag: '--datadir %s',
-      type: 'path'
+      type: 'directory'
     },
     {
       id: 'api',

--- a/ethereum_clients/client_plugins/parity.js
+++ b/ethereum_clients/client_plugins/parity.js
@@ -58,7 +58,7 @@ module.exports = {
     },
     {
       id: 'ipcPath',
-      type: 'path',
+      type: 'directory',
       label: 'IPC Path',
       default: IPC_PATH,
       flag: '--ipc-path %s'

--- a/preload-webview.js
+++ b/preload-webview.js
@@ -1,5 +1,5 @@
 const { ipcRenderer, remote, webFrame } = require('electron')
-const { notify, openFolderDialog } = require('./utils/renderer/electron')
+const { notify, showOpenDialog } = require('./utils/renderer/electron')
 
 const PluginHost = remote.getGlobal('PluginHost')
 
@@ -51,5 +51,5 @@ window.grid = {
     }
   },
   notify,
-  openFolderDialog
+  showOpenDialog
 }

--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,5 @@
 const { ipcRenderer, remote, webFrame } = require('electron')
-const { notify, openFolderDialog } = require('./utils/renderer/electron')
+const { notify, showOpenDialog } = require('./utils/renderer/electron')
 
 // Enabling spectron integration https://github.com/electron/spectron#node-integration
 if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
@@ -58,7 +58,7 @@ const Grid = {
     getArgs: () => currentWindow.args
   },
   notify,
-  openFolderDialog
+  showOpenDialog
 }
 
 /*

--- a/utils/renderer/electron.js
+++ b/utils/renderer/electron.js
@@ -12,7 +12,7 @@ const notify = (title, body) => {
 }
 
 const showOpenDialog = (
-  openDirectory = false,
+  pathType = 'file',
   selectMultiple = false,
   defaultPath
 ) => {
@@ -20,10 +20,10 @@ const showOpenDialog = (
     const options = {
       properties: ['showHiddenFiles']
     }
-    if (openDirectory) {
-      options.properties.push('openDirectory')
-    } else {
+    if (pathType === 'file') {
       options.properties.push('openFile')
+    } else if (pathType === 'directory') {
+      options.properties.push('openDirectory')
     }
     if (selectMultiple) {
       options.properties.push('multiSelections')

--- a/utils/renderer/electron.js
+++ b/utils/renderer/electron.js
@@ -36,7 +36,7 @@ const showOpenDialog = (
         reject('No selection')
         return
       }
-      resolve(filePaths[0])
+      resolve(filePaths.join(','))
     })
   })
 }

--- a/utils/renderer/electron.js
+++ b/utils/renderer/electron.js
@@ -11,11 +11,25 @@ const notify = (title, body) => {
   }
 }
 
-const openFolderDialog = defaultPath => {
+const showOpenDialog = (
+  openDirectory = false,
+  selectMultiple = false,
+  defaultPath
+) => {
   return new Promise((resolve, reject) => {
     const options = {
-      defaultPath,
-      properties: ['openDirectory', 'showHiddenFiles']
+      properties: ['showHiddenFiles']
+    }
+    if (openDirectory) {
+      options.properties.push('openDirectory')
+    } else {
+      options.properties.push('openFile')
+    }
+    if (selectMultiple) {
+      options.properties.push('multiSelections')
+    }
+    if (defaultPath) {
+      options.defaultPath = defaultPath
     }
     dialog.showOpenDialog(options, filePaths => {
       if (!filePaths || filePaths.length === 0) {
@@ -29,5 +43,5 @@ const openFolderDialog = defaultPath => {
 
 module.exports = {
   notify,
-  openFolderDialog
+  showOpenDialog
 }

--- a/utils/renderer/electron.js
+++ b/utils/renderer/electron.js
@@ -20,10 +20,10 @@ const showOpenDialog = (
     const options = {
       properties: ['showHiddenFiles']
     }
-    if (pathType === 'file') {
-      options.properties.push('openFile')
-    } else if (pathType === 'directory') {
+    if (pathType === 'directory') {
       options.properties.push('openDirectory')
+    } else {
+      options.properties.push('openFile')
     }
     if (selectMultiple) {
       options.properties.push('multiSelections')


### PR DESCRIPTION
Renames `openFolderDialog` to `showOpenDialog` and accepts `file` or `directory` (or `file_multiple` or `directory_multiple`)

Closes https://github.com/ethereum/grid/issues/274

Pairs with https://github.com/ethereum/grid-ui/pull/90