### PR TITLE
fix: start ui without waiting for plugin init

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,11 +191,7 @@ const startUI = async () => {
 const onReady = async () => {
   const pluginHost = registerGlobalPluginHost()
 
-  pluginHost.on('plugins-loaded', async () => {
-    // FIXME don't defer start
-    // 1. start UI for quick user-feedback without long init procedures
-    await startUI()
-  })
+  await startUI()
 
   const appManager = registerGlobalAppManager()
 }


### PR DESCRIPTION
#### What does it do?
Grid will no longer wait for remote plugins to be fetched before the `grid-ui` is started.

#### Any helpful background information?
we should get rid of this anti pattern asap. grid uses multiple sources to discover plugins. we do not show a ui to the user until the data store is populated with all plugins. 
this pr requires changes in grid-ui so that either the ui is updated based on events `pluginHost.on('plugins-loaded',...)` or through a redux store living in the `main process` and ipc store sync between different local stores.

related:
https://github.com/ethereum/grid/issues/134
https://github.com/ethereum/grid/issues/296

#### New dependencies? What are they used for?

#### Relevant screenshots?
