### PR TITLE
Nano window visibility control

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -12,6 +12,8 @@ registerGlobalUserConfig()
 // auto-launch may start process with --hidden
 const startMinimized = (process.argv || []).indexOf('--hidden') !== -1
 
+let keepWindowOpen = false
+
 const preloadPath = path.join(__dirname, 'preload.js')
 
 const makePath = p =>
@@ -62,11 +64,24 @@ mb.on('ready', () => {
     mode: 'detach'
   })
   */
+  mb.window.on('blur', function() {
+    // it prevents window from hiding if keepWindowOpen is checked on tray's context menu
+    !keepWindowOpen && mb.hideWindow()
+  })
 })
 
 // right-click menu for tray
 mb.on('after-create-window', function() {
   const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Keep window open',
+      type: 'checkbox',
+      checked: keepWindowOpen,
+      click: () => {
+        keepWindowOpen = !keepWindowOpen
+      }
+    },
+    { type: 'separator' },
     {
       label: 'Feedback',
       click: () => {
@@ -86,9 +101,5 @@ mb.on('after-create-window', function() {
   ])
   mb.tray.on('right-click', () => {
     mb.tray.popUpContextMenu(contextMenu)
-  })
-
-  mb.window.on('blur', function() {
-    mb.hideWindow()
   })
 })

--- a/nano.js
+++ b/nano.js
@@ -87,4 +87,8 @@ mb.on('after-create-window', function() {
   mb.tray.on('right-click', () => {
     mb.tray.popUpContextMenu(contextMenu)
   })
+
+  mb.window.on('blur', function() {
+    mb.hideWindow()
+  })
 })

--- a/preload.js
+++ b/preload.js
@@ -1,10 +1,11 @@
 const { ipcRenderer, remote, webFrame } = require('electron')
 const {
-  notify,
-  showOpenDialog,
-  openExternalLink,
   getLaunchOnBoot,
-  setLaunchOnBoot
+  hideWindow,
+  notify,
+  openExternalLink,
+  setLaunchOnBoot,
+  showOpenDialog
 } = require('./utils/renderer/electron')
 
 // Enabling spectron integration https://github.com/electron/spectron#node-integration
@@ -68,6 +69,7 @@ const Grid = {
   showOpenDialog,
   openExternalLink,
   getLaunchOnBoot,
+  hideWindow,
   setLaunchOnBoot
 }
 

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -475,6 +475,13 @@
       document.body.classList.add(
         distanceToBottom < distanceToTop ? 'docked-to-bottom' : 'docked-to-top'
       )
+
+
+      document.onkeydown = function(evt) {
+        if (evt && evt.key === "Escape") {
+          Grid.hideWindow()
+        }
+      };
     </script>
   </body>
 </html>

--- a/utils/renderer/electron.js
+++ b/utils/renderer/electron.js
@@ -65,10 +65,16 @@ const setLaunchOnBoot = enable => {
   }
 }
 
+const hideWindow = () => {
+  const window = remote.getCurrentWindow()
+  window && window.hide()
+}
+
 module.exports = {
-  notify,
-  showOpenDialog,
-  openExternalLink,
   getLaunchOnBoot,
-  setLaunchOnBoot
+  hideWindow,
+  notify,
+  openExternalLink,
+  setLaunchOnBoot,
+  showOpenDialog
 }


### PR DESCRIPTION
#### What does it do?
- hides window when focus is lost
  1. click on any other app
  1. open "Apps"
  1. open any client config window
- context menu to keep nano opened (super useful for debug or advanced use)

#### Relevant screenshots?
![image](https://user-images.githubusercontent.com/47108/61246906-f783a200-a71d-11e9-853e-69d4cae27081.png)
