### PR TITLE
fix: nano MaxListenersExceededWarning

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1,4 +1,3 @@
-require('events').EventEmitter.defaultMaxListeners = 55
 const path = require('path')
 const { menubar } = require('menubar')
 const { Menu, shell } = require('electron')

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -82,20 +82,21 @@
         margin-left: -2px;
       }
 
-      /* 
+      /*
        * Removes windows and linux window tip.
-       * I'd rather remove the tip on W+L instead of 
-       * adding it only for mac, due to Mac shadow rendering reasons. 
+       * I'd rather remove the tip on W+L instead of
+       * adding it only for mac, due to Mac shadow rendering reasons.
        */
-      body.is-windows .tip, body.is-linux .tip {
+      body.is-windows .tip,
+      body.is-linux .tip {
         display: none;
       }
-      body.is-windows #app, body.is-linux #app {
+      body.is-windows #app,
+      body.is-linux #app {
         height: 100vh;
         margin: 0;
         border-radius: 2px;
       }
-
 
       .client-item {
         padding: 5px;
@@ -280,7 +281,8 @@
             checkbox: [],
             terminalWindowId: undefined,
             uiWindowId: undefined,
-            polling: null
+            polling: null,
+            clientPlugin: null
           }
         },
         template: `
@@ -300,23 +302,20 @@
           `,
         created: function() {
           try {
-            const clientPlugin = window.Grid.PluginHost.getPluginByName(
-              this.client.name
+            this.clientPlugin = this.plugins.find(
+              p => p.name === this.client.name
             )
-            this.listenForStateUpdates(clientPlugin)
+            this.listenForStateUpdates()
           } catch (error) {
             console.log('error polling for state updates', error)
           }
         },
         beforeDestroy: function() {
-          const clientPlugin = window.Grid.PluginHost.getPluginByName(
-            this.client.name
-          )
-          clientPlugin.removeAllListeners('newState')
+          this.clientPlugin.removeAllListeners('newState')
         },
         methods: {
-          listenForStateUpdates: function(clientPlugin) {
-            clientPlugin.on('newState', state => {
+          listenForStateUpdates: function() {
+            this.clientPlugin.on('newState', state => {
               console.log('new state', state)
               this.state = state
 
@@ -483,33 +482,35 @@
         }
       })
 
-      
       // Tip placement, only at startup
       var distanceToBottom =
         window.screen.height - (window.screenTop + window.innerHeight)
       var distanceToTop = window.screenTop
       document.body.classList.add(
-        distanceToBottom < distanceToTop ? 'is-docked-to-bottom' : 'is-docked-to-top'
+        distanceToBottom < distanceToTop
+          ? 'is-docked-to-bottom'
+          : 'is-docked-to-top'
       )
 
       // OS detection
-      var osClass;
-      function checkPlatform(pattern) { return pattern.test(window.navigator.platform) }
+      var osClass
+      function checkPlatform(pattern) {
+        return pattern.test(window.navigator.platform)
+      }
       if (checkPlatform(/win/i)) {
-        osClass = 'is-windows';
+        osClass = 'is-windows'
       } else if (checkPlatform(/mac/i)) {
-        osClass = 'is-mac';
+        osClass = 'is-mac'
       } else {
         osClass = 'is-linux'
       }
       document.body.classList.add(osClass)
 
       document.onkeydown = function(evt) {
-        if (evt && evt.key === "Escape") {
+        if (evt && evt.key === 'Escape') {
           Grid.hideWindow()
         }
-      };
-
+      }
     </script>
   </body>
 </html>

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -84,8 +84,7 @@
 
       /*
        * Removes windows and linux window tip.
-       * I'd rather remove the tip on W+L instead of
-       * adding it only for mac, due to Mac shadow rendering reasons.
+       * Mac on by default for shadow rendering reasons.
        */
       body.is-windows .tip,
       body.is-linux .tip {
@@ -281,7 +280,6 @@
             checkbox: [],
             terminalWindowId: undefined,
             uiWindowId: undefined,
-            polling: null,
             clientPlugin: null
           }
         },
@@ -301,14 +299,8 @@
           </div>
           `,
         created: function() {
-          try {
-            this.clientPlugin = this.plugins.find(
-              p => p.name === this.client.name
-            )
-            this.listenForStateUpdates()
-          } catch (error) {
-            console.log('error polling for state updates', error)
-          }
+          this.clientPlugin = this.plugins.find(p => p.name === this.client.name)
+          this.listenForStateUpdates()
         },
         beforeDestroy: function() {
           this.clientPlugin.removeAllListeners('newState')

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -279,8 +279,7 @@
             downloadProgress: 0,
             checkbox: [],
             terminalWindowId: undefined,
-            uiWindowId: undefined,
-            clientPlugin: null
+            uiWindowId: undefined
           }
         },
         template: `
@@ -299,15 +298,14 @@
           </div>
           `,
         created: function() {
-          this.clientPlugin = this.plugins.find(p => p.name === this.client.name)
           this.listenForStateUpdates()
         },
         beforeDestroy: function() {
-          this.clientPlugin.removeAllListeners('newState')
+          this.client.plugin.removeAllListeners('newState')
         },
         methods: {
           listenForStateUpdates: function() {
-            this.clientPlugin.on('newState', state => {
+            this.client.plugin.on('newState', state => {
               console.log('new state', state)
               this.state = state
 
@@ -318,17 +316,17 @@
               }
             })
           },
-          handleSwitchedOn: async function(clientPlugin) {
+          handleSwitchedOn: async function() {
             // check if downloaded version is available
-            let latestBinCached = await clientPlugin.getLatestCached()
+            let latestBinCached = await this.client.plugin.getLatestCached()
             if (!latestBinCached) {
               console.log('no client binary found --> download now')
-              const latestRemote = await clientPlugin.getLatestRemote()
+              const latestRemote = await this.client.plugin.getLatestRemote()
               // TODO handle no remote release found
               try {
                 this.state = 'downloading'
                 this.isDownloading = true
-                latestBinCached = await clientPlugin.download(
+                latestBinCached = await this.client.plugin.download(
                   latestRemote,
                   downloadProgress => {
                     console.log('download progress', downloadProgress)
@@ -348,21 +346,17 @@
 
             console.log('cached release found --> start now')
             const persistedFlags = (await Grid.Config.getItem('flags')) || {}
-            const flags = persistedFlags[clientPlugin.name]
+            const flags = persistedFlags[this.client.plugin.name]
 
-            clientPlugin.start(latestBinCached, flags)
+            this.client.plugin.start(latestBinCached, flags)
           },
           handleChange: function(ev) {
-            // get reference to plugin
-            const clientPlugin = window.Grid.PluginHost.getPluginByName(
-              this.client.name
-            )
             if (this.isSwitched) {
-              this.handleSwitchedOn(clientPlugin)
+              this.handleSwitchedOn()
             } else {
               // TODO cancel download if currently running
               if (['started', 'starting', 'connected'].includes(this.state)) {
-                clientPlugin.stop()
+                this.client.plugin.stop()
               }
             }
           },
@@ -449,11 +443,12 @@
         methods: {
           init: function() {
             const plugins = window.Grid.PluginHost.getAllPlugins()
-            this.clients = plugins.map(p => ({
-              name: p.name,
-              displayName: p.displayName,
+            this.clients = plugins.map(plugin => ({
+              name: plugin.name,
+              displayName: plugin.displayName,
               profile: '',
-              version: ''
+              version: '',
+              plugin
             }))
             console.log('plugins loaded', plugins.length)
           },


### PR DESCRIPTION
#### What does it do?
Fixes `MaxListenersExceededWarning` in nano due to calling 

```js
const clientPlugin = window.Grid.PluginHost.getPluginByName(this.client.name)
```
every time list is rendered (i.e. switching back and forth from settings cog).

Fixes by passing in a reference to the plugin through the `client` prop.

---

For future consideration, we should revisit the PluginProxy architecture so a `new PluginProxy` isn't created every time on `getAllPlugins()` and `getPluginByName()`:
```js
  getAllPlugins() {
    return this.plugins.map(p => new PluginProxy(p))
  }
  getPluginByName(name) {
    return this.getAllPlugins().find(p => p.name === name)
  }
```
which in turn calls memory leaking function in `PluginProxy` constructor `registerEventListeners()`:
```js
  registerEventListeners(sourceEmitter, destEmitter) {
    // FIXME memory leaks start here:
    // forward all events from the spawned process
    let eventTypes = ['newState', 'error', 'log', 'notification']
    eventTypes.forEach(eventName => {
      sourceEmitter.on(eventName, arg => {
        if (eventName !== 'log') {
          console.log(`forward external process event >> ${eventName}`)
        }
        destEmitter.emit(eventName, arg)
      })
    })
  }
```