### PR TITLE
fix: nano switch color

### DIFF
--- a/ui/nano.html
+++ b/ui/nano.html
@@ -21,13 +21,13 @@
         margin-right: 4px;
       }
       .switch input[type='checkbox']:checked + .check {
-        background: #57d57e;
+        background: #54B684;
       }
       .switch:hover input[type='checkbox']:checked + .check {
-        background: rgba(87, 213, 126, 0.9);
+        background: rgba(84, 182, 132, 0.9);
       }
       .switch input[type='checkbox']:focus:checked + .check {
-        box-shadow: 0 0 0.5em rgba(87, 213, 126, 0.8);
+        box-shadow: 0 0 0.5em rgba(84, 182, 132, 0.8);
       }
 
       .switch input[type='checkbox'] + .check {


### PR DESCRIPTION
#### What does it do?
Matches nano switch color to the same green used by grid-ui.
#### Any helpful background information?
Hunting for release blog post screenshots.
#### Relevant screenshots?
<img width="572" alt="Screen Shot 2019-07-18 at 5 14 03 PM" src="https://user-images.githubusercontent.com/3621728/61496540-ba1b5080-a979-11e9-8ccf-ae048f67def0.png">
