### PR TITLE
fix: launches AppManager windows in center with offset

### DIFF
--- a/WindowManager.js
+++ b/WindowManager.js
@@ -1,4 +1,5 @@
-const { BrowserWindow, ipcMain } = require('electron')
+const electron = require('electron')
+const { BrowserWindow, ipcMain } = electron
 const path = require('path')
 const fs = require('fs')
 
@@ -30,13 +31,13 @@ class WindowManager {
       height: 658
     }
 
-    // Open new window in offset to existing window if exists
-    const focusedWindow = BrowserWindow.getFocusedWindow()
-    if (focusedWindow) {
-      const position = focusedWindow.getPosition()
-      baseOptions.x = position[0] + 35
-      baseOptions.y = position[1] + 35
-    }
+    // Open new window in center with offset
+    const offset = 35 * (BrowserWindow.getAllWindows().length - 1)
+    let bounds = electron.screen.getPrimaryDisplay().bounds
+    baseOptions.x =
+      Math.ceil(bounds.x + (bounds.width - baseOptions.width) / 2) + offset
+    baseOptions.y =
+      Math.ceil(bounds.y + (bounds.height - baseOptions.height) / 2) + offset
 
     if (options.title) {
       baseOptions.title = options.title

--- a/grid_apps/AppManager.js
+++ b/grid_apps/AppManager.js
@@ -92,7 +92,7 @@ class AppManager extends EventEmitter {
     return apps
   }
   async launch(app) {
-    console.log('launch', app.name)
+    console.log(`Launch: ${app.name}`)
 
     if (app.id) {
       const win = WindowManager.getById(app.id)
@@ -110,17 +110,13 @@ class AppManager extends EventEmitter {
       if (component === 'terminal') {
         appUrl = `file://${path.join(__dirname, '..', 'ui', 'terminal.html')}`
       }
-      const clientDisplayName = 'Geth'
       let mainWindow = createRenderer(
         appUrl,
         {
-          x: 400,
-          y: 400,
-          backgroundColor: component === 'terminal' ? '#1E1E1E' : '#202225'
+          backgroundColor: component === 'terminal' ? '#1E1E1E' : '#202225',
+          title: 'Grid'
         },
-        {
-          scope
-        }
+        { scope }
       )
       mainWindow.setMenu(null)
       /*
@@ -128,7 +124,6 @@ class AppManager extends EventEmitter {
         mode: 'detach'
       })
       */
-      mainWindow.setTitle('Ethereum Grid Terminal for ' + clientDisplayName)
       return mainWindow.id
     }
 

--- a/nano.js
+++ b/nano.js
@@ -30,7 +30,8 @@ const mb = menubar({
     height: 420,
     webPreferences: {
       preload: preloadPath
-    }
+    },
+    title: 'Grid Nano'
   },
   icon: path.resolve(`${__dirname}/build/IconTemplate.png`)
 })


### PR DESCRIPTION
#### What does it do?
My center offset code was being thrown off by new nano menubar, so there was a x/y coordinate hardcoded in.

This fixes with better logic to calculate opening to center of screen with offset based on number of open windows (except nano).

To test:
1. Start Grid
1. Click on 'Geth' in Nano, grid-ui should open in center
1. Without closing previous window, click on 'IPFS' in Nano, grid-ui should open in center offset

<img width="1198" alt="Screen Shot 2019-07-20 at 11 14 26 PM" src="https://user-images.githubusercontent.com/22116/61587725-2649b000-ab44-11e9-8b01-aa51b2f599a5.png">
