### PR TITLE
fix: properly spaces nano title

### DIFF
--- a/ui/nano.html
+++ b/ui/nano.html
@@ -216,7 +216,7 @@
         margin: 5px 0;
       }
       .grid-logo {
-        transform: translateX(12px) /* half of cog icon's width */
+        transform: translateX(28px) /* half of cog + app icon's width */
       }
       #grid-version {
         font-size: 0.8rem;


### PR DESCRIPTION
#### What does it do?
With the addition of the Apps icon, the "grid" logo got pushed further to the left, off-center.

before:
<img width="356" alt="Screen Shot 2019-07-23 at 4 18 54 PM" src="https://user-images.githubusercontent.com/3621728/61752812-6ab69500-ad6a-11e9-9c5c-d8208c4b9d53.png">
after:
<img width="358" alt="Screen Shot 2019-07-23 at 4 23 04 PM" src="https://user-images.githubusercontent.com/3621728/61752823-7b670b00-ad6a-11e9-9874-6e5886e38f8a.png">
