### PR TITLE
fix: window visibility control

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -18,7 +18,7 @@ const makePath = p =>
 
 const mb = menubar({
   browserWindow: {
-    alwaysOnTop: false,
+    alwaysOnTop: true,
     transparent: true,
     backgroundColor: '#00FFFFFF',
     frame: false,

--- a/nano.js
+++ b/nano.js
@@ -11,8 +11,6 @@ registerGlobalUserConfig()
 // auto-launch may start process with --hidden
 const startMinimized = (process.argv || []).indexOf('--hidden') !== -1
 
-let keepWindowOpen = false
-
 const preloadPath = path.join(__dirname, 'preload.js')
 
 const makePath = p =>
@@ -20,7 +18,7 @@ const makePath = p =>
 
 const mb = menubar({
   browserWindow: {
-    alwaysOnTop: true, // good for debugging
+    alwaysOnTop: false,
     transparent: true,
     backgroundColor: '#00FFFFFF',
     frame: false,
@@ -74,9 +72,10 @@ const init = function(mb) {
       {
         label: 'Keep window open',
         type: 'checkbox',
-        checked: keepWindowOpen,
+        checked: mb.window.alwaysOnTop,
         click: () => {
-          keepWindowOpen = !keepWindowOpen
+          // Toggles alwaysOnTop property of nano window
+          mb.window.setAlwaysOnTop(!mb.window.isAlwaysOnTop())
         }
       },
       { type: 'separator' },

--- a/nano.js
+++ b/nano.js
@@ -105,6 +105,8 @@ const init = function(mb) {
     mb.tray.on('right-click', () => {
       mb.tray.popUpContextMenu(contextMenu)
     })
+
+    mb.window.on('hide', () => mb.hideWindow())
   })
 }
 

--- a/nano.js
+++ b/nano.js
@@ -66,11 +66,6 @@ const init = function(mb) {
     //   mb.showWindow()
     // }
     mb.showWindow()
-
-    mb.window.on('blur', function() {
-      // it prevents window from hiding if keepWindowOpen is checked on tray's context menu
-      !keepWindowOpen && mb.hideWindow()
-    })
   })
 
   // right-click menu for tray


### PR DESCRIPTION
### What does it do?

This PR attempts to fix those two behaviors, on mac and win:

1) removes blur event, attempting to fix windows issue. https://github.com/ethereum/grid/commit/77f59e47bb4fd303fa73be55a9f3879f5b221e70
![grid-nano-tray-bug](https://user-images.githubusercontent.com/47108/61805665-2ed00e00-ae04-11e9-81af-2c38869892c6.gif)

2) now, whenever a user closes nano using Esc key on Mac, the icon should not remove its highlighted state (a side-effect of changes made in **1**). https://github.com/ethereum/grid/commit/244babe32c7be3820b0ab1632af6d87cdfe2ed2c

<img src="https://user-images.githubusercontent.com/47108/61805574-06e0aa80-ae04-11e9-933b-cc7c2e48f756.gif" width=50%>

3) changes context menu checkbox to toggle AlwaysOnTop property. https://github.com/ethereum/grid/commit/7e27eb0d2715f3a83694d99de7268e29c9b8d057


#### Testing template
- [ ] it worked properly on mac
- [ ] it worked properly on windows
- [ ] alwaysOnTop toggle on menu worked as expected