### PR TITLE
fix: change `removeEventListener` to `off` to fix error

### DIFF
--- a/ui/nano.html
+++ b/ui/nano.html
@@ -380,10 +380,7 @@
           }
         },
         beforeDestroy: function() {
-          this.client.plugin.removeEventListener(
-            'newState',
-            this.stateUpdateListener
-          )
+          this.client.plugin.off('newState', this.stateUpdateListener)
         },
         methods: {
           stateUpdateListener: function(state) {
@@ -594,7 +591,7 @@
         },
         beforeDestroy: function() {
           plugins.forEach(plugin => {
-            plugin.removeEventListener('pluginError', this.pluginErrorListener)
+            plugin.off('pluginError', this.pluginErrorListener)
           })
         }
       })


### PR DESCRIPTION
#### What does it do?
Uses the correct API for plugin, using `off` instead of `removeEventListener`

There should be no more errors in console when switching over to the settings cog.

---

Fixes https://github.com/ethereum/grid/issues/382