### PR TITLE
fix: match error to whole word for pluginError

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -124,7 +124,7 @@ class ControlledProcess extends EventEmitter {
           this.logs.push(...parts)
           parts.map(logPart => {
             this.emit('log', logPart)
-            if (logPart.toLowerCase().includes('error')) {
+            if (/^error\W/.test(logPart.toLowerCase())) {
               this.emit('pluginError', logPart)
             }
           })


### PR DESCRIPTION
#### What does it do?
Matches error as a separate whole word to pass as pluginError

Fixes https://github.com/ethereum/grid/issues/385 