### PR TITLE
fix: remove duplicate Apps links

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -86,9 +86,7 @@ const init = function(mb) {
       {
         label: 'Feedback',
         click: () => {
-          shell.openExternal(
-            'https://docs.google.com/forms/d/e/1FAIpQLSeJ4BtbvDVSnIFCKG6TmJo_tbSZql-NBZHes_-M6SyTDTjP0Q/viewform'
-          )
+          shell.openExternal('https://forms.gle/bjkphVS8ca1JzwL46')
           mb.hideWindow()
         }
       },

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -512,24 +512,13 @@
         },
         template: `
           <div class="grid-config">
-            <div><a v-on:click="openApps()">View Apps</a></div>
             <div><a @click.prevent="openExternal('https://github.com/ethereum/grid')">Grid Repository</a></div>
+            <div><a @click.prevent="openExternal('https://forms.gle/bjkphVS8ca1JzwL46')">Feedback</a></div>
             <div class="separator"></div>
             <div><b-switch v-model="launchOnBoot" @input="handleChangeLaunch($event)" size="is-small">Start Grid at log in</b-switch></div>
           </div>
           `,
         methods: {
-          openApps: async function() {
-            this.appsWindowId = await window.Grid.AppManager.launch({
-              name: 'grid-ui',
-              id: this.appsWindowId,
-              args: {
-                scope: {
-                  component: 'apps'
-                }
-              }
-            })
-          },
           openExternal: function(href) {
             window.Grid.openExternalLink(href)
           },


### PR DESCRIPTION
#### What does it do?
Replaces "View Apps" link with a feedback form link, since the Apps page link was added to the top of nano.
#### Relevant screenshots?
<img width="432" alt="Screen Shot 2019-07-29 at 12 47 05 PM" src="https://user-images.githubusercontent.com/3621728/62074017-1a728380-b1ff-11e9-9351-14ff3673c3b3.png">
