### PR TITLE
fix: nano does not go fullscreen on macos

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -33,6 +33,7 @@ const mb = menubar({
     backgroundColor: '#00FFFFFF',
     frame: false,
     resizable: false,
+    fullscreenable: false,
     width: 320,
     height: 420,
     webPreferences: {


### PR DESCRIPTION
#### What does it do?
It preserves nano window size and does not stretch it out when going fullscreen from any of grid UI windows.

#### Relevant screenshots?
![image](https://user-images.githubusercontent.com/47108/62477344-d17a7c00-b776-11e9-9e70-ac33d10b5bbb.png)
