### PR TITLE
fix: small bug fixes and improvements mostly related to app-manager

### DIFF
--- a/ethereum_clients/PluginHost.js
+++ b/ethereum_clients/PluginHost.js
@@ -163,19 +163,16 @@ class PluginHost extends EventEmitter {
             cacheDir: getPluginCachePath(pluginShortInfo.name)
           })
           // load package from cache or server:
-          let latest = await pluginManager.getLatest()
+          let latest = await pluginManager.getLatest({
+            download: true // download if necessary -> no cached found
+          })
+
           if (!latest) {
-            return undefined
+            throw new Error(
+              `Error: Plugin ${pluginName} could not be retrieved.`
+            )
           }
-          // download if necessary -> no cached found
-          if (latest.remote) {
-            latest = await pluginManager.download(latest)
-            if (!latest) {
-              throw new Error(
-                `Error: Plugin ${pluginName} could not be fetched.`
-              )
-            }
-          }
+
           // plugin verification necessary for remote plugins:
           if (!latest.verificationResult) {
             throw new Error(

--- a/grid_apps/AppManager.js
+++ b/grid_apps/AppManager.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const path = require('path')
+const fs = require('fs')
 const createRenderer = require('../electron-shell')
 const WindowManager = require('../WindowManager')
 const {
@@ -220,7 +221,7 @@ class AppManager extends EventEmitter {
         },
         { scope }
       )
-      mainWindow.setMenu(null)
+      // mainWindow.setMenu(null)
       /*
       mainWindow.webContents.openDevTools({
         mode: 'detach'
@@ -230,6 +231,24 @@ class AppManager extends EventEmitter {
     }
 
     let url = app.url || 'http://localhost:3000'
+
+    const appCache = getCachePath(app.name)
+    // console.log('checking cache', appCache)
+    const pkgManager = new PackageManager({
+      repository: app.url.replace('package:', 'https:'),
+      auto: false, // this will automatically check for new packages...
+      cacheDir: appCache, // updates are downloaded to this path
+      policy: {
+        onlySigned: false
+      }
+    })
+    const cached = await pkgManager.getLatestCached()
+    if (cached) {
+      // console.log('cached app found', cached)
+      let appUrl = await gridUiManager.load(cached.location)
+      url = appUrl
+    }
+
     const mainWindow = createRenderer(
       await getGridUiUrl(), // FIXME might be very inefficient. might load many grid-ui packages into memory!!
       {},

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release": "env-cmd .env yarn run build:grid"
   },
   "dependencies": {
-    "@philipplgh/electron-app-manager": "^0.45.0",
+    "@philipplgh/electron-app-manager": "^0.46.0",
     "auto-launch": "^5.0.5",
     "debug": "^4.1.1",
     "menubar": "^6.0.7",

--- a/scripts/copyApp.js
+++ b/scripts/copyApp.js
@@ -4,17 +4,17 @@
 const { getShippedGridUiPath } = require('../utils/main/util')
 const { AppManager } = require('@philipplgh/electron-app-manager')
 
-const updater = new AppManager({
-  repository: 'https://github.com/ethereum/grid-ui',
-  auto: false
-})
-
 const GRID_UI_CACHE = getShippedGridUiPath()
 
+const updater = new AppManager({
+  repository: 'https://github.com/ethereum/grid-ui',
+  auto: false,
+  cacheDir: GRID_UI_CACHE
+})
+
 ;(async function() {
-  const latest = await updater.getLatestRemote()
-  await updater.download(latest, {
-    targetDir: GRID_UI_CACHE,
-    writeDetachedMetadata: false
+  await updater.clearCache()
+  await updater.getLatest({
+    download: true
   })
 })()

--- a/ui/nano.html
+++ b/ui/nano.html
@@ -406,50 +406,48 @@
             }
           },
           handleSwitchedOn: async function() {
-            let release
-            // Check if selectedRelease in UserConfig
-            const selectedRelease = this.client.plugin.getSelectedRelease()
-            if (selectedRelease) {
-              this.clientVersion = selectedRelease.version
-              release = selectedRelease
-            }
 
-            if (!release) {
-              // Check if downloaded version is available
-              let latestBinCached = await this.client.plugin.getLatestCached()
-              if (!latestBinCached) {
-                console.log('no client binary found --> download now')
-                const latestRemote = await this.client.plugin.getLatestRemote()
-                // TODO handle no remote release found
-                try {
-                  this.state = 'downloading'
+            let listener = (newState, args) => {
+              switch(newState){
+                case 'release-found': {
+                  this.clientVersion = selectedRelease.version
+                  release = selectedRelease
+                  break;
+                }
+                case 'download-started': {
                   this.isDownloading = true
-                  latestBinCached = await this.client.plugin.download(
-                    latestRemote,
-                    downloadProgress => {
-                      console.log('download progress', downloadProgress)
-                      this.downloadProgress = downloadProgress
-                      this.state = `downloading ${downloadProgress}%`
-                    }
-                  )
+                  this.state = 'downloading'
+                  break;
+                }
+                case 'download-progress': {
+                  let { downloadProgress } = args
+                  console.log('download progress', downloadProgress)
+                  this.downloadProgress = downloadProgress
+                  this.state = `downloading ${downloadProgress}%`
+                  break;
+                }
+                case 'download-stopped': {
                   this.isDownloading = false
                   this.state = ''
-                } catch (error) {
-                  console.log('error during download', error)
-                  return //TODO handleDownloadError(error)
+                  break;
                 }
               }
-              console.log('Cached release found')
-              this.clientVersion = latestBinCached.version
-              release = latestBinCached
             }
 
-            console.log('Starting release: ', release.version)
+            try {
+              const persistedFlags = (await Grid.Config.getItem('flags')) || {}
+              const flags = persistedFlags[this.client.plugin.name]
 
-            const persistedFlags = (await Grid.Config.getItem('flags')) || {}
-            const flags = persistedFlags[this.client.plugin.name]
+              // if we pass undefined as release the plugin will try to determine the best 
+              // release automatically and download it if necessary
+              let release = undefined
+              
+              await this.client.plugin.start(release, flags, listener)
 
-            this.client.plugin.start(release, flags)
+            } catch (error) {
+              console.log('error during start', error)
+            } finally {
+            }
           },
           handleChange: function(ev) {
             if (this.isSwitched) {


### PR DESCRIPTION
#### What does it do?

- replaces some redundant and repeating logic such as:
`latest = getLatest()-> if remote -> download(latest)`
with a new API in electron-app-manager: `getLatest({download: true})`

- moves similar logic from the nano UI into grid so that the one-click-setup functionality can be used across multiple UIs.

- fixes the platform arch filter

#### Any helpful background information?

#### New dependencies? What are they used for?

requires new app-manager version 0.46.0

#### Relevant screenshots?
