### PR TITLE
fix: adds uppercase geth sync labels

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -79,7 +79,11 @@ module.exports = {
       id: 'syncMode',
       default: 'light',
       label: 'Sync Mode',
-      options: ['fast', 'full', 'light'],
+      options: [
+        { value: 'fast', label: 'Fast' },
+        { value: 'full', label: 'Full' },
+        { value: 'light', label: 'Light' }
+      ],
       flag: '--syncmode %s'
     },
     {


### PR DESCRIPTION
#### What does it do?
Capitalizes geth sync labels.
#### Any helpful background information?
This was driving me nuts. These values were the only ones not capitalized in the form.
#### Relevant screenshots?
before:
<img width="556" alt="Screen Shot 2019-08-20 at 3 04 49 PM" src="https://user-images.githubusercontent.com/3621728/63384853-fa953200-c35c-11e9-9989-c55f780a79b7.png">
