### PR TITLE
chore: bump grid version to 1.6.0 for next milestone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grid",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Ethereum Grid",
   "main": "nano.js",
   "homepage": "https://github.com/ethereum/grid",


### PR DESCRIPTION
#### What does it do?
Bumps version to `1.6.0`

`1.6.0` milestone: https://github.com/ethereum/grid/milestone/3
