### PR TITLE
fix: nano download progress

### DIFF
--- a/ui/nano.html
+++ b/ui/nano.html
@@ -433,7 +433,6 @@
             }
           },
           handleSwitchedOn: async function() {
-            const { client } = this
             let release
             // Check if selectedRelease in UserConfig
             const selectedRelease = this.plugin.pluginRef.getSelectedRelease()


### PR DESCRIPTION
#### What does it do?
Fixes nano download progress bar due to old ref not being updated

Example steps to test:
1. Delete geth bin folder at `~/Library/Application Support/Grid/app_cache/bin/bin_geth`
1. Delete `~/Library/Application Support/Grid/config.json`
1. Start grid
1. Toggle geth on in nano
1. Confirm download progress bar updates