### PR TITLE
feat: introduces required flags for parity

### DIFF
--- a/ethereum_clients/client_plugins/parity.js
+++ b/ethereum_clients/client_plugins/parity.js
@@ -63,6 +63,18 @@ module.exports = {
       label: 'IPC Path',
       default: IPC_PATH,
       flag: '--ipc-path %s'
+    },
+    {
+      required: true,
+      id: 'noDownload',
+      default: 'required',
+      options: [{ value: 'required', flag: '--no-download' }]
+    },
+    {
+      required: true,
+      id: 'forceDirect',
+      default: 'required',
+      options: [{ value: 'required', flag: '--force-direct' }]
     }
   ],
   about: {


### PR DESCRIPTION
#### What does it do?
Introduces `required` flags. Closes https://github.com/ethereum/grid/issues/442
#### Any helpful background information?
I like this solution because: 
A) the plugin config code is a little verbose, but requires no changes to the complicated flag generation logic, and 
B) users can still go wild and override the flags in the custom flag section

Note: assuming you have some stored values for Parity configs, you will likely have to toggle custom flags on and off to see the new ones appear.
#### Relevant screenshots?
<img width="1212" alt="Screen Shot 2019-08-28 at 4 17 39 PM" src="https://user-images.githubusercontent.com/3621728/63896492-61df6180-c9af-11e9-8cec-794e129099d6.png">
