### PR TITLE
fix: shut down lingering plugins

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -68,8 +68,24 @@ const init = function(mb) {
   const template = getMenuTemplate()
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 
+  const pluginHost = registerGlobalPluginHost()
+
+  app.on('quit', () => {
+    const plugins = pluginHost.getAllPlugins()
+    plugins.forEach(p => {
+      if (!p.plugin.process || p.plugin.process.state === 'STOPPED') {
+        console.log('Successfully shut down plugin:', p.name)
+      } else {
+        const proc = p.plugin.process.proc
+        if (!proc.killed) {
+          console.log('Forcefully shutting down plugin:', p.name)
+          proc.kill('SIGINT')
+        }
+      }
+    })
+  })
+
   mb.on('ready', () => {
-    const pluginHost = registerGlobalPluginHost()
     const appManager = registerGlobalAppManager()
 
     // Unsure of linux distros behavior with menubar

--- a/nano.js
+++ b/nano.js
@@ -74,13 +74,10 @@ const init = function(mb) {
     const plugins = pluginHost.getAllPlugins()
     plugins.forEach(p => {
       if (!p.plugin.process || p.plugin.process.state === 'STOPPED') {
-        console.log('Successfully shut down plugin:', p.name)
+        console.log('Plugin already stopped:', p.name)
       } else {
-        const proc = p.plugin.process.proc
-        if (!proc.killed) {
-          console.log('Forcefully shutting down plugin:', p.name)
-          proc.kill('SIGINT')
-        }
+        console.log('Forcefully shutting down plugin:', p.name)
+        p.plugin.process.proc.kill('SIGINT')
       }
     })
   })


### PR DESCRIPTION
#### What does it do?
Shuts down lingering processes on quit. Closes #267.
#### Any helpful background information?
Moved the instantiation of the PluginHost out of the `mb.on('ready', () => {})` callback function. I didn't notice any unintended consequences, but its possible there are implications I'm not aware of. 👀 appreciated.
#### Screenshots
<img width="299" alt="Screen Shot 2019-08-29 at 4 20 14 PM" src="https://user-images.githubusercontent.com/3621728/63980606-6708e300-ca79-11e9-8e18-9be13613496b.png">
