### PR TITLE
feat: clear errors in nano on plugin event `clearPluginErrors`

### DIFF
--- a/ui/nano.html
+++ b/ui/nano.html
@@ -541,9 +541,17 @@
           },
           openUI: async function() {
             const settings = Grid.Config.getItem('settings')
+
+            let selectedTab = 0
+            if (this.plugin.error) {
+              // If error, got to Terminal tab
+              selectedTab = 3
+              this.plugin.error = false
+            }
+
             const newSettings = Object.assign({}, settings, {
               selected: this.plugin.name,
-              selectedTab: 0
+              selectedTab
             })
             Grid.Config.setItem('settings', newSettings)
 
@@ -676,6 +684,9 @@
               plugin.on('pluginError', error => {
                 this.pluginErrorListener(plugin, error)
               })
+              plugin.on('clearPluginErrors', () => {
+                this.clearPluginErrors(plugin)
+              })
               return {
                 name: plugin.name,
                 displayName: plugin.displayName,
@@ -698,6 +709,9 @@
           },
           pluginErrorListener: function(plugin, error) {
             this.plugins.find(p => p.name === plugin.name).error = true
+          },
+          clearPluginErrors: function(plugin) {
+            this.plugins.find(p => p.name === plugin.name).error = false
           },
           toggleSettings: function(value) {
             this.showConfig = value
@@ -733,6 +747,7 @@
         beforeDestroy: function() {
           plugins.forEach(plugin => {
             plugin.off('pluginError', this.pluginErrorListener)
+            plugin.off('clearPluginErrors', this.clearPluginErrors)
           })
         }
       })


### PR DESCRIPTION
#### What does it do?
Fixes https://github.com/ethereum/grid/issues/418

* Clears error in nano when receiving the plugin event `clearPluginErrors`
  * added in https://github.com/ethereum/grid-ui/pull/139
* If a plugin has an error, clicking on its title will bring you direct to Terminal tab

![ezgif-3-fd8dcc88d419](https://user-images.githubusercontent.com/22116/64045907-5dd25180-cb1f-11e9-9a4a-373a7d69b19a.gif)