### PR TITLE
fix: hide nano on blur for mac

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -10,10 +10,11 @@ const { getCachePath } = require('./utils/main/util')
 registerPackageProtocol(getCachePath('apps'))
 registerGlobalUserConfig()
 
-// auto-launch may start process with --hidden
+// Auto-launch may start process with --hidden
 const startMinimized = (process.argv || []).indexOf('--hidden') !== -1
 
-let alwaysOnTop = true
+// Due to a bug, do not autohide nano on blur for Windows
+let alwaysOnTop = !process.platform === 'darwin'
 
 const preloadPath = path.join(__dirname, 'preload.js')
 

--- a/nano.js
+++ b/nano.js
@@ -13,7 +13,10 @@ registerGlobalUserConfig()
 // Auto-launch may start process with --hidden
 const startMinimized = (process.argv || []).indexOf('--hidden') !== -1
 
-// Due to a bug, do not autohide nano on blur for Windows
+// Do not autohide nano on blur for Windows
+// As we cannot guarantee the icon will be on the visible area 
+// of user's notification area in Windows, we set it to a "sticky mode" by default
+// Windows users can still close Nano with <Esc> or <Control+W>.
 let alwaysOnTop = !process.platform === 'darwin'
 
 const preloadPath = path.join(__dirname, 'preload.js')


### PR DESCRIPTION
#### What does it do?
Hides nano onBlur for mac.
#### Any helpful background information?
I believe this is the ideal UX, but Windows can't handle it due to a bug (which I can't recall the specifics of anymore - if someone does, it may be helpful to include more context in the comment.)