### PR TITLE
Fix: menubar contextMenu on linux

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -66,7 +66,7 @@ const init = function() {
         }
       },
       {
-        label: 'Keep window open',
+        label: 'Always on Top',
         type: 'checkbox',
         checked: alwaysOnTop,
         click: () => {

--- a/nano.js
+++ b/nano.js
@@ -54,17 +54,7 @@ const init = function() {
   app.on('ready', () => {
     const tray = new Tray(iconPath())
 
-    const menuOptions = [
-      {
-        label: 'Toggle window',
-        click: () => {
-          if (mb.window.isVisible()) {
-            mb.hideWindow()
-          } else {
-            mb.showWindow()
-          }
-        }
-      },
+    let menuOptions = [
       {
         label: 'Always on Top',
         type: 'checkbox',
@@ -91,6 +81,19 @@ const init = function() {
         }
       }
     ]
+
+    if (process.platform !== 'mac') {
+      menuOptions.unshift({
+        label: 'Toggle Window',
+        click: () => {
+          if (mb.window.isVisible()) {
+            mb.hideWindow()
+          } else {
+            mb.showWindow()
+          }
+        }
+      })
+    }
 
     const contextMenu = Menu.buildFromTemplate(menuOptions)
 

--- a/nano.js
+++ b/nano.js
@@ -118,8 +118,7 @@ const init = function() {
     })
 
     mb.on('ready', () => {
-      const pluginHost = registerGlobalPluginHost()
-      const appManager = registerGlobalAppManager()
+      registerGlobalAppManager()
 
       // Unsure of linux distros behavior with menubar
       // so for now we will always show on launch


### PR DESCRIPTION
#### What does it do?

- Fixes blank `contextMenu` for menubar icon on Linux.
- Adds "Toggle window" menu option as this is the only way to do display Nano on Linux.
- Uses higher resolution icon, borrowed from macos.

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?
![VirtualBox_ubuntu-18 04 2_19_09_2019_13_01_19](https://user-images.githubusercontent.com/47108/65264910-a5744980-dadd-11e9-97e4-e3d6aa05e5e8.png)


#### Test instructions
My tests were made on Ubuntu 18.04 (Virtualbox) and Amazon Linux (AWS Workspaces), which is RedHat/CentOS based.

1. Grab Grid binaries from the [CI job](https://circleci.com/gh/ethereum/grid/2627)
2. Load it to your VM
3. Profit

Closes #398 
