### PR TITLE
fix: binary path variable cache was preventing other versions to be extracted

### DIFF
--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -154,12 +154,6 @@ class Plugin extends EventEmitter {
     return this.updater.download(release, { onProgress })
   }
   async getLocalBinary(release) {
-    if (this.binPath) {
-      return {
-        binaryPath: this.binPath
-      }
-    }
-
     const extractBinary = async (pkg, binaryName) => {
       const entries = await this.updater.getEntries(pkg)
       let binaryEntry = undefined

--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -188,9 +188,16 @@ class Plugin extends EventEmitter {
         fs.unlinkSync(destAbs)
       }
       // IMPORTANT: if the binary already exists the mode cannot be set
-      fs.writeFileSync(destAbs, await binaryEntry.file.readContent(), {
-        mode: parseInt('754', 8) // strict mode prohibits octal numbers in some cases
-      })
+      fs.writeFileSync(
+        destAbs,
+        await binaryEntry.file.readContent(),
+        {
+          mode: parseInt('754', 8) // strict mode prohibits octal numbers in some cases
+        },
+        err => {
+          throw `Error while writing binary: ${err}`
+        }
+      )
 
       // cache the binary path
       this.binPath = destAbs

--- a/ethereum_clients/Plugin.js
+++ b/ethereum_clients/Plugin.js
@@ -376,10 +376,10 @@ class Plugin extends EventEmitter {
         binaryPath: binaryPathExtracted,
         packagePath
       } = await this.getLocalBinary(release)
+      binaryPath = binaryPathExtracted
       console.log(
         `Plugin ${this.name} (${packagePath}) about to start. Binary: ${binaryPath}`
       )
-      binaryPath = binaryPathExtracted
     }
 
     try {


### PR DESCRIPTION
#### What does it do?

It allows extraction of clients from its packages for multiple times, and not only once.

This PR removes the caching of the variable `this.binPath` on Plugin.js.

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?
