### PR TITLE
fix: add null check

### DIFF
--- a/ethereum_clients/ControlledProcess.js
+++ b/ethereum_clients/ControlledProcess.js
@@ -90,7 +90,7 @@ class ControlledProcess extends EventEmitter {
           this.emit('newState', 'stopped')
         }
 
-        if (code !== 0) {
+        if (code && code !== 0) {
           // Closing with any code other than 0 means there was an error
           const errorMessage = `${this.name} child process exited with code: ${code}`
           this.emitPluginError(errorMessage)


### PR DESCRIPTION
#### What does it do? Does it close any issues?
I was experiencing on the Windows VM anytime I turned off a plugin I would get this error message:

<img width="471" alt="Screen Shot 2019-10-02 at 10 53 35 PM" src="https://user-images.githubusercontent.com/22116/66102733-38929200-e568-11e9-8547-f702c106fac1.png">

This PR adds a null check to that error message.