### PR TITLE
fix: default geth keystore dir

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -22,7 +22,7 @@ switch (process.platform) {
   }
 }
 
-const keystoreDir = `${dataDir}/Ethereum`
+const keystoreDir = `${dataDir}/keystore`
 
 const findIpcPathInLogs = logs => {
   let ipcPath


### PR DESCRIPTION
#### What does it do? Does it close any issues?
For some reason, the keystore dir for geth was being set incorrectly. This fixes that.