### PR TITLE
chore: bump version (1.6.2)

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -1,11 +1,13 @@
 let platform = 'windows'
 let dataDir = `${process.env.APPDATA}/Ethereum`
+let keystoreDir = `${dataDir}/keystore`
 
 // Platform specific initialization
 switch (process.platform) {
   case 'win32': {
     platform = 'windows'
     dataDir = `${process.env.APPDATA}\\Ethereum`
+    keystoreDir = `${dataDir}\\keystore`
     break
   }
   case 'linux': {
@@ -21,8 +23,6 @@ switch (process.platform) {
   default: {
   }
 }
-
-const keystoreDir = `${dataDir}/keystore`
 
 const findIpcPathInLogs = logs => {
   let ipcPath

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grid",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Ethereum Grid",
   "main": "nano.js",
   "homepage": "https://github.com/ethereum/grid",


### PR DESCRIPTION
#### What does it do?
chore: bump version (1.6.2), and better formatting of keystorePath for windows