### PR TITLE
feat: ignore flag if empty

### DIFF
--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -1,3 +1,5 @@
+const platform = process.platform === 'win32' ? 'windows' : process.platform
+
 const findIpcPathInLogs = logs => {
   let ipcPath
   for (const logPart of logs) {
@@ -31,11 +33,11 @@ module.exports = {
   },
   filter: {
     name: {
-      includes: [process.platform],
+      includes: [platform],
       excludes: ['unstable', 'alltools', 'swarm', 'mips', 'arm']
     }
   },
-  prefix: `geth-${process.platform}`,
+  prefix: `geth-${platform}`,
   binaryName: process.platform === 'win32' ? 'geth.exe' : 'geth',
   resolveIpc: logs => findIpcPathInLogs(logs),
   settings: [

--- a/ethereum_clients/client_plugins/geth.js
+++ b/ethereum_clients/client_plugins/geth.js
@@ -1,30 +1,3 @@
-let platform = 'windows'
-let dataDir = `${process.env.APPDATA}/Ethereum`
-
-// Platform specific initialization
-switch (process.platform) {
-  case 'win32': {
-    platform = 'windows'
-    dataDir = `${process.env.APPDATA}\\Ethereum`
-    break
-  }
-  case 'linux': {
-    platform = 'linux'
-    dataDir = '~/.ethereum'
-    break
-  }
-  case 'darwin': {
-    platform = 'darwin'
-    dataDir = '~/Library/Ethereum'
-    break
-  }
-  default: {
-  }
-}
-
-const keystoreDir =
-  process.platform === 'win32' ? `${dataDir}\\keystore` : `${dataDir}/keystore`
-
 const findIpcPathInLogs = logs => {
   let ipcPath
   for (const logPart of logs) {
@@ -58,11 +31,11 @@ module.exports = {
   },
   filter: {
     name: {
-      includes: [platform],
+      includes: [process.platform],
       excludes: ['unstable', 'alltools', 'swarm', 'mips', 'arm']
     }
   },
-  prefix: `geth-${platform}`,
+  prefix: `geth-${process.platform}`,
   binaryName: process.platform === 'win32' ? 'geth.exe' : 'geth',
   resolveIpc: logs => findIpcPathInLogs(logs),
   settings: [
@@ -91,17 +64,19 @@ module.exports = {
     },
     {
       id: 'dataDir',
-      default: dataDir,
+      default: '',
       label: 'Data Directory',
       flag: '--datadir %s',
-      type: 'directory'
+      type: 'directory',
+      ignoreIfEmpty: true
     },
     {
       id: 'keystoreDir',
-      default: keystoreDir,
+      default: '',
       label: 'Keystore Directory',
       flag: '--keystore %s',
-      type: 'directory'
+      type: 'directory',
+      ignoreIfEmpty: true
     },
     {
       id: 'console',

--- a/utils/flags.js
+++ b/utils/flags.js
@@ -1,11 +1,15 @@
 /**
- * This method preserves spaces contained in the value.
+ * This method:
+ * 1) returns nothing if ignoreIfEmpty && value === ''
+ * 2) preserves spaces contained in the value.
  * input: "--ipc '%s'", "/path with spaces"
  * output: ["--ipc", "/path with spaces"]
  */
-const parseFlag = (pattern, value) => {
-  let result = pattern.split(' ').map(e => e.replace(/%s/, value))
-
+const parseFlag = (pattern, value, ignoreIfEmpty) => {
+  if (ignoreIfEmpty && !value) {
+    return ''
+  }
+  const result = pattern.split(' ').map(e => e.replace(/%s/, value))
   return result
 }
 
@@ -40,7 +44,11 @@ const generateFlags = (userConfig, nodeSettings) => {
       throw new Error(`Config entry "${entry}" must have the "flag" key`)
     }
 
-    const parsedFlag = parseFlag(pattern, userConfig[entry])
+    const parsedFlag = parseFlag(
+      pattern,
+      userConfig[entry],
+      configEntry.ignoreIfEmpty
+    )
     flags = flags.concat(parsedFlag)
   })
 


### PR DESCRIPTION
#### What does it do? Does it close any issues?
Removes trying to define default data directory and keystore directory across platforms, and instead introduces property `ignoreIfEmpty` to flag settings.

Closes one of the issues in #512

Pairs with https://github.com/ethereum/grid-ui/pull/159

---

To test, run this branch with the paired grid-ui branch and see what your values in Settings are for Geth for `Data Directory` and `Keystore Directory`. Clear them empty, and see if the generated flags hide --datadir and/or --keystoredir